### PR TITLE
Rediseña la celda A1 del cuaderno y añade funcionalidad

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1061,3 +1061,64 @@ body.cpp-no-text-select {
 }
 
 /* --- FIN: Estilos para Menú de Usuario --- */
+
+/* --- INICIO: Rediseño Celda A1 --- */
+
+.cpp-cuaderno-th-alumno .cpp-a1-controls-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: stretch; /* Estirar items */
+    height: 100%;
+    padding: 8px;
+}
+
+.cpp-a1-evaluacion-selector {
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+#cpp-evaluacion-selector {
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 4px;
+    background-color: #f1f3f4;
+    color: #3c4043;
+    border: 1px solid #e0e0e0;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23333333' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    background-size: 1em;
+    padding-right: 2rem;
+    cursor: pointer;
+}
+
+#cpp-evaluacion-selector:focus {
+    outline: none;
+    border-color: #1a73e8;
+    box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.2);
+}
+
+.cpp-a1-icons-row {
+    display: flex;
+    justify-content: space-around; /* Distribuir los iconos */
+    align-items: center;
+    width: 100%;
+    gap: 4px; /* Espacio reducido entre iconos */
+}
+
+.cpp-a1-icons-row .cpp-btn-icon {
+    flex-grow: 1; /* Para que ocupen el espacio disponible */
+}
+
+.cpp-a1-icons-row .cpp-btn-icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+/* --- FIN: Rediseño Celda A1 --- */

--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -25,16 +25,23 @@
             }
         },
 
-        updateEnterDirectionButton: function() {
-            const $button = $('#cpp-a1-enter-direction-btn');
+        updateSortButton: function(sortOrder) {
+            const $button = $('#cpp-a1-sort-students-btn');
             if (!$button.length) return;
-            const $icon = $button.find('.dashicons');
-            if (this.enterKeyDirection === 'down') {
-                $icon.removeClass('dashicons-arrow-right-alt2').addClass('dashicons-arrow-down-alt2');
-                $button.attr('title', 'Desplazar hacia abajo al pulsar Intro (clic para cambiar a derecha)');
+
+            const icons = {
+                apellidos: '<svg class="icon-sort-alpha" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 18l-4-4h3V4h2v10h3l-4 4zM4.75 5.5H10c.83 0 1.5-.67 1.5-1.5S10.83 2.5 10 2.5H4.75c-.83 0-1.5.67-1.5 1.5S3.92 5.5 4.75 5.5zM10.25 8.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5zM10.25 14.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5z"/></svg>',
+                nombre: '<svg class="icon-sort-alpha" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 18l-4-4h3V4h2v10h3l-4 4zM4.5 11.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5zM4.75 5.5H10c.83 0 1.5-.67 1.5-1.5S10.83 2.5 10 2.5H4.75c-.83 0-1.5.67-1.5 1.5S3.92 5.5 4.75 5.5zM10.25 14.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5z"/></svg>'
+            };
+
+            if (sortOrder === 'nombre') {
+                $button.html(icons.nombre);
+                $button.attr('title', 'Ordenado por Nombre (clic para cambiar a Apellidos)');
+                $button.data('sort', 'nombre');
             } else {
-                $icon.removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-right-alt2');
-                $button.attr('title', 'Desplazar hacia la derecha al pulsar Intro (clic para cambiar a abajo)');
+                $button.html(icons.apellidos);
+                $button.attr('title', 'Ordenado por Apellidos (clic para cambiar a Nombre)');
+                $button.data('sort', 'apellidos');
             }
         },
         
@@ -55,7 +62,7 @@
             $container.html(selectHtml);
         },
         
-        cargarContenidoCuaderno: function(claseId, claseNombre, evaluacionId) {
+        cargarContenidoCuaderno: function(claseId, claseNombre, evaluacionId, sortOrder) {
             const $contenidoCuaderno = $('#cpp-cuaderno-contenido');
             cpp.currentClaseIdCuaderno = claseId;
 
@@ -77,7 +84,7 @@
                 const self = this;
 
                 const ajaxAction = isFinalView ? 'cpp_cargar_vista_final' : 'cpp_cargar_cuaderno_clase';
-                let ajaxData = { nonce: cppFrontendData.nonce, clase_id: claseId };
+                let ajaxData = { nonce: cppFrontendData.nonce, clase_id: claseId, sort_order: sortOrder || 'apellidos' };
                 if (!isFinalView && evaluacionId) {
                     ajaxData.evaluacion_id = evaluacionId;
                 }
@@ -98,7 +105,7 @@
                             $('#clase_id_actividad_cuaderno_form').val(claseId);
 
                             if (response.data.nombre_clase && (cpp.utils && typeof cpp.utils.updateTopBarClassName === 'function')) { cpp.utils.updateTopBarClassName(response.data.nombre_clase); }
-                            self.updateEnterDirectionButton();
+                            self.updateSortButton(response.data.sort_order);
                             self.clearCellSelection();
                             self.selectionStartCellInput = null;
                         } else {
@@ -174,7 +181,21 @@
                 const nuevaEvaluacionId = $(this).val();
                 if (cpp.currentClaseIdCuaderno && nuevaEvaluacionId) {
                     const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
-                    self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, nuevaEvaluacionId);
+                    const sortOrder = $('#cpp-a1-sort-students-btn').data('sort');
+                    self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, nuevaEvaluacionId, sortOrder);
+                }
+            });
+
+            $document.on('click', '#cpp-a1-sort-students-btn', function(e) {
+                e.preventDefault();
+                const $button = $(this);
+                const currentSort = $button.data('sort');
+                const newSort = currentSort === 'apellidos' ? 'nombre' : 'apellidos';
+                $button.data('sort', newSort);
+
+                if (cpp.currentClaseIdCuaderno) {
+                    const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
+                    self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, cpp.currentEvaluacionId, newSort);
                 }
             });
 
@@ -190,7 +211,7 @@
                 }
             });
 
-            $cuadernoContenido.on('keydown', '.cpp-input-nota', function(e) { self.manejarNavegacionTablaNotas.call(this, e); }); $cuadernoContenido.on('blur', '.cpp-input-nota', function(e) { self.guardarNotaDesdeInput.call(this, e, null); }); $cuadernoContenido.on('focusin', '.cpp-input-nota', function(e){ self.limpiarErrorNotaInput(this); this.select(); if (typeof $(this).data('original-nota-set') === 'undefined' || !$(this).data('original-nota-set')) { $(this).data('original-nota', $(this).val().trim()); $(this).data('original-nota-set', true); } }); $cuadernoContenido.on('focusout', '.cpp-input-nota', function(e){ $(this).removeData('original-nota-set'); }); $cuadernoContenido.on('dragstart', '.cpp-input-nota', function(e) { e.preventDefault(); }); $cuadernoContenido.on('click', 'td.cpp-cuaderno-td-alumno', function(e){ self.handleClickAlumnoCell.call(this, e); }); $cuadernoContenido.on('click', 'th.cpp-cuaderno-th-final', function(e){ self.handleClickNotaFinalHeader.call(this, e); }); $cuadernoContenido.on('click', '.cpp-cuaderno-th-actividad', function(e){ if (cpp.modals && cpp.modals.actividades && typeof cpp.modals.actividades.cargarParaEditar === 'function') { cpp.modals.actividades.cargarParaEditar(this, e); } else { console.error("Función cpp.modals.actividades.cargarParaEditar no encontrada."); } }); $document.on('click', '#cpp-a1-add-activity-btn', function(e) { e.stopPropagation(); if (cpp.modals && cpp.modals.actividades && typeof cpp.modals.actividades.mostrarAnadir === 'function') { cpp.modals.actividades.mostrarAnadir(); } else { console.error("Función cpp.modals.actividades.mostrarAnadir no encontrada."); } }); $document.on('click', '#cpp-a1-import-students-btn', function(e){ if (cpp.modals && cpp.modals.excel && typeof cpp.modals.excel.showImportStudents === 'function') { cpp.modals.excel.showImportStudents(e); } else { console.error("Función cpp.modals.excel.showImportStudents no encontrada.");} }); $document.on('click', '#cpp-a1-download-excel-btn', function(e){ if (cpp.modals && cpp.modals.excel && typeof cpp.modals.excel.showDownloadOptions === 'function') { cpp.modals.excel.showDownloadOptions(e); } else { console.error("Función cpp.modals.excel.showDownloadOptions no encontrada.");} }); $document.on('click', '#cpp-a1-take-attendance-btn', function(e) { e.preventDefault(); e.stopPropagation(); if (cpp.modals && cpp.modals.asistencia && typeof cpp.modals.asistencia.mostrar === 'function') { if (cpp.currentClaseIdCuaderno) { cpp.modals.asistencia.mostrar(cpp.currentClaseIdCuaderno); } else { alert("Por favor, selecciona o carga una clase primero."); } } else { console.error("Función cpp.modals.asistencia.mostrar no encontrada."); } }); $document.on('click', '#cpp-a1-enter-direction-btn', function(e) { e.preventDefault(); e.stopPropagation(); if (self.enterKeyDirection === 'down') { self.enterKeyDirection = 'right'; } else { self.enterKeyDirection = 'down'; } self.updateEnterDirectionButton(); if (typeof localStorage !== 'undefined' && cppFrontendData && cppFrontendData.userId && cppFrontendData.userId !== '0') { try { localStorage.setItem(self.localStorageKey_enterDirection + cppFrontendData.userId, self.enterKeyDirection); } catch (lsError) { console.warn("No se pudo guardar la preferencia de dirección de Enter en localStorage:", lsError); } } }); $document.on('mousedown', '.cpp-cuaderno-tabla .cpp-input-nota', function(e) { self.handleCellMouseDown.call(this, e); }); $document.on('copy', function(e) { const activeElement = document.activeElement; if ((activeElement && $(activeElement).closest('.cpp-cuaderno-tabla').length) || (self.currentSelectedInputs && self.currentSelectedInputs.length > 0)) { self.handleCopyCells(e); } }); $document.on('paste', '.cpp-cuaderno-tabla .cpp-input-nota', function(e) { self.handlePasteCells.call(this, e); }); }
+            $document.on('click', '#cpp-a1-download-excel-btn', function(e){ if (cpp.modals && cpp.modals.excel && typeof cpp.modals.excel.showDownloadOptions === 'function') { cpp.modals.excel.showDownloadOptions(e); } else { console.error("Función cpp.modals.excel.showDownloadOptions no encontrada.");} }); $document.on('click', '#cpp-a1-take-attendance-btn', function(e) { e.preventDefault(); e.stopPropagation(); if (cpp.modals && cpp.modals.asistencia && typeof cpp.modals.asistencia.mostrar === 'function') { if (cpp.currentClaseIdCuaderno) { cpp.modals.asistencia.mostrar(cpp.currentClaseIdCuaderno); } else { alert("Por favor, selecciona o carga una clase primero."); } } else { console.error("Función cpp.modals.asistencia.mostrar no encontrada."); } }); $document.on('mousedown', '.cpp-cuaderno-tabla .cpp-input-nota', function(e) { self.handleCellMouseDown.call(this, e); }); $document.on('copy', function(e) { const activeElement = document.activeElement; if ((activeElement && $(activeElement).closest('.cpp-cuaderno-tabla').length) || (self.currentSelectedInputs && self.currentSelectedInputs.length > 0)) { self.handleCopyCells(e); } }); $document.on('paste', '.cpp-cuaderno-tabla .cpp-input-nota', function(e) { self.handlePasteCells.call(this, e); }); }
     };
 
 })(jQuery);

--- a/includes/ajax-handlers/ajax-cuaderno.php
+++ b/includes/ajax-handlers/ajax-cuaderno.php
@@ -11,6 +11,7 @@ function cpp_ajax_cargar_cuaderno_clase() {
     $user_id = get_current_user_id();
     $clase_id = isset($_POST['clase_id']) ? intval($_POST['clase_id']) : 0;
     $evaluacion_id_solicitada = isset($_POST['evaluacion_id']) ? intval($_POST['evaluacion_id']) : null;
+    $sort_order = isset($_POST['sort_order']) && in_array($_POST['sort_order'], ['nombre', 'apellidos']) ? $_POST['sort_order'] : 'apellidos';
 
     if (empty($clase_id)) { wp_send_json_error(['message' => 'ID de clase no proporcionado.']); return; }
 
@@ -47,7 +48,7 @@ function cpp_ajax_cargar_cuaderno_clase() {
         }
     }
 
-    $alumnos = cpp_obtener_alumnos_clase($clase_id);
+    $alumnos = cpp_obtener_alumnos_clase($clase_id, $sort_order);
     $actividades_raw = cpp_obtener_actividades_por_clase($clase_id, $user_id, $evaluacion_activa_id);
     $calificaciones_raw = cpp_obtener_calificaciones_cuaderno($clase_id, $user_id, $evaluacion_activa_id);
     $categorias_evaluacion = cpp_obtener_categorias_por_evaluacion($evaluacion_activa_id, $user_id);
@@ -77,9 +78,10 @@ function cpp_ajax_cargar_cuaderno_clase() {
     ?>
     <div class="cpp-fixed-top-bar" style="background-color: <?php echo esc_attr($clase_color_actual); ?>; color: <?php echo esc_attr($texto_color_barra_fija); ?>;">
         <div class="cpp-top-bar-left">
-            <button class="cpp-btn-icon cpp-top-bar-menu-btn" id="cpp-a1-menu-btn-toggle" title="Menú de clases"><span class="dashicons dashicons-menu-alt"></span></button>
+            <button class="cpp-btn-icon cpp-top-bar-menu-btn" id="cpp-a1-menu-btn-toggle" title="Menú de clases">
+                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+            </button>
             <span id="cpp-cuaderno-nombre-clase-activa-a1" class="cpp-top-bar-class-name"><?php echo esc_html($clase_db->nombre); ?></span>
-            <div id="cpp-evaluacion-selector-container" class="cpp-top-bar-selector-container"></div>
         </div>
         <div class="cpp-top-bar-right">
             <div class="cpp-user-menu-container">
@@ -103,12 +105,23 @@ function cpp_ajax_cargar_cuaderno_clase() {
                 <tr>
                     <th class="cpp-cuaderno-th-alumno">
                         <div class="cpp-a1-controls-container">
+                            <div id="cpp-evaluacion-selector-container" class="cpp-a1-evaluacion-selector"></div>
                             <div class="cpp-a1-icons-row">
-                                <button class="cpp-btn-icon" id="cpp-a1-take-attendance-btn" title="Pasar Lista"><span class="dashicons dashicons-list-view"></span></button>
-                                <button class="cpp-btn-icon" id="cpp-a1-enter-direction-btn" title="Desplazar hacia abajo al pulsar Intro (clic para cambiar)"><span class="dashicons dashicons-arrow-down-alt2"></span></button>
-                                <button class="cpp-btn-icon" id="cpp-a1-import-students-btn" title="Importar Alumnos desde Excel"><span class="dashicons dashicons-upload"></span></button>
-                                <button class="cpp-btn-icon" id="cpp-a1-download-excel-btn" title="Descargar Excel"><span class="dashicons dashicons-download"></span></button>
-                                <button class="cpp-btn-icon" id="cpp-a1-add-activity-btn" title="Añadir Actividad"><span class="dashicons dashicons-plus-alt"></span></button>
+                                <button class="cpp-btn-icon" id="cpp-a1-sort-students-btn" title="Ordenar por Apellidos" data-sort="apellidos">
+                                    <svg class="icon-sort-alpha" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 18l-4-4h3V4h2v10h3l-4 4zM4.75 5.5H10c.83 0 1.5-.67 1.5-1.5S10.83 2.5 10 2.5H4.75c-.83 0-1.5.67-1.5 1.5S3.92 5.5 4.75 5.5zM10.25 8.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5zM10.25 14.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-take-attendance-btn" title="Pasar Lista">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7v-5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-import-students-btn" title="Importar Alumnos desde Excel">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-download-excel-btn" title="Descargar Excel">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13v4h-2v-4H8v-2h7V7h2v4h2v2h-4z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-add-activity-btn" title="Añadir Actividad">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4 11h-3v3h-2v-3H8v-2h3V8h2v3h3v2z"/></svg>
+                                </button>
                             </div>
                         </div>
                     </th>
@@ -155,7 +168,10 @@ function cpp_ajax_cargar_cuaderno_clase() {
                         if ($base_nota_final_clase == floor($base_nota_final_clase)) { if (isset($notas_finales_alumnos[$alumno['id']]) && $notas_finales_alumnos[$alumno['id']] == floor($notas_finales_alumnos[$alumno['id']])) { $decimales_nota_final = 0; } }
                         $nota_final_display = isset($notas_finales_alumnos[$alumno['id']]) ? cpp_formatear_nota_display($notas_finales_alumnos[$alumno['id']], $decimales_nota_final) : '-';
                     ?>
-                        <tr data-alumno-id="<?php echo esc_attr($alumno['id']); ?>" <?php echo $row_style_attr; ?>><td class="cpp-cuaderno-td-alumno"><div class="cpp-alumno-avatar-cuaderno"><?php if(!empty($alumno['foto'])):?><img src="<?php echo esc_url($alumno['foto']);?>" alt="Foto <?php echo esc_attr($alumno['nombre']); ?>"><?php else:?><span><?php echo strtoupper(substr(esc_html($alumno['nombre']),0,1));?></span><?php endif;?></div><span class="cpp-alumno-nombre-cuaderno"><?php echo esc_html($alumno['apellidos'] . ', ' . $alumno['nombre']); ?></span></td><?php if (empty($actividades_raw)): ?><td class="cpp-cuaderno-td-no-actividades"></td>
+                        <?php
+                            $nombre_completo_display = ($sort_order === 'nombre') ? ($alumno['nombre'] . ' ' . $alumno['apellidos']) : ($alumno['apellidos'] . ', ' . $alumno['nombre']);
+                        ?>
+                        <tr data-alumno-id="<?php echo esc_attr($alumno['id']); ?>" <?php echo $row_style_attr; ?>><td class="cpp-cuaderno-td-alumno"><div class="cpp-alumno-avatar-cuaderno"><?php if(!empty($alumno['foto'])):?><img src="<?php echo esc_url($alumno['foto']);?>" alt="Foto <?php echo esc_attr($alumno['nombre']); ?>"><?php else:?><span><?php echo strtoupper(substr(esc_html($alumno['nombre']),0,1));?></span><?php endif;?></div><span class="cpp-alumno-nombre-cuaderno"><?php echo esc_html($nombre_completo_display); ?></span></td><?php if (empty($actividades_raw)): ?><td class="cpp-cuaderno-td-no-actividades"></td>
                             <?php else: foreach ($actividades_raw as $actividad):
                                     $nota_alumno_actividad_raw = isset($calificaciones_raw[$alumno['id']][$actividad['id']]) ? $calificaciones_raw[$alumno['id']][$actividad['id']] : '';
                                     $nota_alumno_actividad_display = cpp_formatear_nota_display($nota_alumno_actividad_raw);
@@ -171,7 +187,8 @@ function cpp_ajax_cargar_cuaderno_clase() {
     wp_send_json_success([
         'html_cuaderno' => $html_cuaderno, 'nombre_clase' => $clase_db->nombre, 'evaluaciones' => $evaluaciones,
         'evaluacion_activa_id' => $evaluacion_activa_id, 'calculo_nota' => $metodo_calculo,
-        'base_nota_final' => $base_nota_final_clase
+        'base_nota_final' => $base_nota_final_clase,
+        'sort_order' => $sort_order
     ]);
 }
 
@@ -291,12 +308,13 @@ function cpp_ajax_cargar_vista_final() {
     global $wpdb;
     $user_id = get_current_user_id();
     $clase_id = isset($_POST['clase_id']) ? intval($_POST['clase_id']) : 0;
+    $sort_order = isset($_POST['sort_order']) && in_array($_POST['sort_order'], ['nombre', 'apellidos']) ? $_POST['sort_order'] : 'apellidos';
     if (empty($clase_id)) { wp_send_json_error(['message' => 'ID de clase no proporcionado.']); return; }
 
     $clase_db = $wpdb->get_row($wpdb->prepare("SELECT id, nombre, user_id, color, base_nota_final FROM {$wpdb->prefix}cpp_clases WHERE id = %d AND user_id = %d", $clase_id, $user_id));
     if (!$clase_db) { wp_send_json_error(['message' => 'Clase no encontrada o no tienes permiso.']); return; }
 
-    $alumnos = cpp_obtener_alumnos_clase($clase_id);
+    $alumnos = cpp_obtener_alumnos_clase($clase_id, $sort_order);
     $evaluaciones_reales = cpp_obtener_evaluaciones_por_clase($clase_id, $user_id);
     $base_nota_final_clase = isset($clase_db->base_nota_final) ? floatval($clase_db->base_nota_final) : 100.00;
     $clase_color_actual = isset($clase_db->color) && !empty($clase_db->color) ? $clase_db->color : '#2962FF';
@@ -316,9 +334,10 @@ function cpp_ajax_cargar_vista_final() {
     ?>
     <div class="cpp-fixed-top-bar" style="background-color: <?php echo esc_attr($clase_color_actual); ?>; color: <?php echo esc_attr($texto_color_barra_fija); ?>;">
         <div class="cpp-top-bar-left">
-            <button class="cpp-btn-icon cpp-top-bar-menu-btn" id="cpp-a1-menu-btn-toggle" title="Menú de clases"><span class="dashicons dashicons-menu-alt"></span></button>
+            <button class="cpp-btn-icon cpp-top-bar-menu-btn" id="cpp-a1-menu-btn-toggle" title="Menú de clases">
+                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+            </button>
             <span id="cpp-cuaderno-nombre-clase-activa-a1" class="cpp-top-bar-class-name"><?php echo esc_html($clase_db->nombre); ?></span>
-            <div id="cpp-evaluacion-selector-container" class="cpp-top-bar-selector-container"></div>
         </div>
         <div class="cpp-top-bar-right">
             <div class="cpp-user-menu-container">
@@ -340,7 +359,28 @@ function cpp_ajax_cargar_vista_final() {
         <table class="cpp-cuaderno-tabla">
             <thead>
                 <tr>
-                    <th class="cpp-cuaderno-th-alumno"></th>
+                    <th class="cpp-cuaderno-th-alumno">
+                        <div class="cpp-a1-controls-container">
+                            <div id="cpp-evaluacion-selector-container" class="cpp-a1-evaluacion-selector"></div>
+                            <div class="cpp-a1-icons-row">
+                                <button class="cpp-btn-icon" id="cpp-a1-sort-students-btn" title="Ordenar por Apellidos" data-sort="apellidos">
+                                    <svg class="icon-sort-alpha" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 18l-4-4h3V4h2v10h3l-4 4zM4.75 5.5H10c.83 0 1.5-.67 1.5-1.5S10.83 2.5 10 2.5H4.75c-.83 0-1.5.67-1.5 1.5S3.92 5.5 4.75 5.5zM10.25 8.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5zM10.25 14.5H4.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5h5.75c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-take-attendance-btn" title="Pasar Lista">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7v-5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-import-students-btn" title="Importar Alumnos desde Excel">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-download-excel-btn" title="Descargar Excel">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13v4h-2v-4H8v-2h7V7h2v4h2v2h-4z"/></svg>
+                                </button>
+                                <button class="cpp-btn-icon" id="cpp-a1-add-activity-btn" title="Añadir Actividad">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4 11h-3v3h-2v-3H8v-2h3V8h2v3h3v2z"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    </th>
                     <?php foreach ($evaluaciones_reales as $evaluacion): ?>
                         <th class="cpp-cuaderno-th-actividad"><?php echo esc_html($evaluacion['nombre_evaluacion']); ?></th>
                     <?php endforeach; ?>
@@ -353,12 +393,15 @@ function cpp_ajax_cargar_vista_final() {
                 <?php else: foreach ($alumnos as $index => $alumno):
                         $row_style_attr = ($index % 2 != 0) ? 'style="background-color: ' . esc_attr(cpp_lighten_hex_color($clase_color_actual, 0.95)) . ';"' : '';
                     ?>
+                    <?php
+                        $nombre_completo_display = ($sort_order === 'nombre') ? ($alumno['nombre'] . ' ' . $alumno['apellidos']) : ($alumno['apellidos'] . ', ' . $alumno['nombre']);
+                    ?>
                     <tr data-alumno-id="<?php echo esc_attr($alumno['id']); ?>" <?php echo $row_style_attr; ?>>
                         <td class="cpp-cuaderno-td-alumno">
                             <div class="cpp-alumno-avatar-cuaderno">
                                 <?php if(!empty($alumno['foto'])):?><img src="<?php echo esc_url($alumno['foto']);?>" alt="Foto <?php echo esc_attr($alumno['nombre']); ?>"><?php else:?><span><?php echo strtoupper(substr(esc_html($alumno['nombre']),0,1));?></span><?php endif;?>
                             </div>
-                            <span class="cpp-alumno-nombre-cuaderno"><?php echo esc_html($alumno['apellidos'] . ', ' . $alumno['nombre']); ?></span>
+                            <span class="cpp-alumno-nombre-cuaderno"><?php echo esc_html($nombre_completo_display); ?></span>
                         </td>
                         <?php foreach ($evaluaciones_reales as $evaluacion):
                             $nota_0_100 = $notas_por_evaluacion[$alumno['id']][$evaluacion['id']];
@@ -391,5 +434,6 @@ function cpp_ajax_cargar_vista_final() {
         'evaluaciones' => $evaluaciones_con_final,
         'evaluacion_activa_id' => 'final',
         'nombre_clase' => $clase_db->nombre,
+        'sort_order' => $sort_order
     ]);
 }

--- a/includes/db-queries/queries-alumnos.php
+++ b/includes/db-queries/queries-alumnos.php
@@ -5,9 +5,17 @@ defined('ABSPATH') or die('Acceso no permitido');
 
 // --- FUNCIONES PARA ALUMNOS ---
 
-function cpp_obtener_alumnos_clase($clase_id) {
+function cpp_obtener_alumnos_clase($clase_id, $sort_order = 'apellidos') {
     global $wpdb;
-    $query = $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}cpp_alumnos WHERE clase_id = %d ORDER BY apellidos, nombre", $clase_id );
+    $order_by_clause = 'apellidos, nombre';
+    if ($sort_order === 'nombre') {
+        $order_by_clause = 'nombre, apellidos';
+    }
+
+    $query = $wpdb->prepare(
+        "SELECT * FROM {$wpdb->prefix}cpp_alumnos WHERE clase_id = %d ORDER BY $order_by_clause",
+        $clase_id
+    );
     return $wpdb->get_results($query, ARRAY_A);
 }
 


### PR DESCRIPTION
Este commit rediseña completamente la celda A1 de la tabla del cuaderno para mejorar la usabilidad y el aspecto visual.

Los cambios principales son:
- El selector de evaluaciones se ha movido desde la barra superior a la parte superior de la celda A1, ocupando todo su ancho para un acceso más fácil.
- Se ha añadido un nuevo botón que permite al usuario alternar el orden de los alumnos entre nombre y apellidos.
- Los botones de acción existentes se han movido a la parte inferior de la celda A1.
- Los iconos de los botones, que antes eran de Dashicons, han sido reemplazados por SVGs más modernos y visualmente atractivos.
- Se ha eliminado el botón para cambiar la dirección de la tecla 'Intro' para simplificar la interfaz.

Se han actualizado los archivos PHP, JavaScript y CSS para implementar estos cambios de manera consistente en todo el plugin.