### PR TITLE
Fix(JS): Resolve parsing error in student file modal

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1237,3 +1237,94 @@ body.cpp-no-text-select {
 }
 
 /* --- END: Final Grade Button Styles --- */
+
+/* --- START: Ficha Alumno Tabs --- */
+
+.cpp-ficha-tabs {
+    display: flex;
+    border-bottom: 1px solid #e0e0e0;
+    margin-bottom: 20px;
+}
+
+.cpp-ficha-tab-btn {
+    padding: 10px 20px;
+    cursor: pointer;
+    background-color: transparent;
+    border: none;
+    font-size: 15px;
+    font-weight: 500;
+    color: #5f6368;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -1px; /* Overlap the container's border */
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.cpp-ficha-tab-btn:hover {
+    color: #202124;
+}
+
+.cpp-ficha-tab-btn.active {
+    color: #1a73e8;
+    border-bottom-color: #1a73e8;
+}
+
+.cpp-ficha-tab-content {
+    display: none;
+}
+
+.cpp-ficha-tab-content.active {
+    display: block;
+}
+
+/* --- END: Ficha Alumno Tabs --- */
+
+/* --- START: Ficha Alumno Category Breakdown --- */
+
+.cpp-ficha-evaluacion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+}
+
+.cpp-ficha-evaluacion-item {
+    padding: 10px 0;
+    border-bottom: 1px solid #e9ecef;
+}
+.cpp-ficha-evaluacion-item:last-child {
+    border-bottom: none;
+}
+
+.cpp-ficha-lista-categorias-desglose {
+    list-style: none;
+    padding-left: 20px;
+    margin: 10px 0 0 0;
+    border-top: 1px dashed #e0e0e0;
+    padding-top: 10px;
+}
+
+.cpp-ficha-categoria-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 0;
+    font-size: 13px;
+}
+
+.cpp-ficha-categoria-nombre {
+    color: #5f6368;
+}
+.cpp-ficha-categoria-nombre small {
+    color: #80868b;
+}
+
+.cpp-ficha-categoria-nota {
+    font-weight: 500;
+    color: #3c4043;
+    background-color: #f8f9fa;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+/* --- END: Ficha Alumno Category Breakdown --- */

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -106,10 +106,10 @@
 
             if (resumen.stats) {
                 html += '<div class="cpp-ficha-stats-grid">';
-                html += `<div class="stat-item"><span class="stat-icon">✅</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">❌</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">🕒</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">📄</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">(P)</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">(A)</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">(R)</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">(J)</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
                 html += '</div>';
             }
 
@@ -227,7 +227,7 @@
                     $btn.prop('disabled', false).html(originalBtnHtml);
                 }
             });
-        },
+        }
 
         bindEvents: function() {
             console.log("Binding Modals Ficha Alumno events...");

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -1,251 +1,27 @@
-// assets/js/cpp-modales-ficha-alumno.js
+// assets/js/cpp-modales-ficha-alumno.js - DEBUGGING VERSION 1.1
 (function($) {
     'use strict';
 
     if (typeof cpp === 'undefined') {
-        console.error("Error: El objeto 'cpp' (de cpp-core.js) no está definido. El módulo cpp-modales-ficha-alumno.js no puede inicializarse.");
+        console.error("DEBUG: 'cpp' object not found for fichaAlumno.");
         return;
     }
     cpp.modals = cpp.modals || {};
 
+    console.log("DEBUG: Loading sanity-check version of cpp-modales-ficha-alumno.js");
+
     cpp.modals.fichaAlumno = {
-        currentAlumnoId: null,
-        currentClaseId: null,
-
         init: function() {
-            console.log("CPP Modals Ficha Alumno Module Initializing...");
-            this.bindEvents();
+             console.log("DEBUG: fichaAlumno init() called.");
         },
-
-        resetModal: function() {
-            const $modal = $('#cpp-modal-ficha-alumno');
-            if (!$modal.length) return;
-            $modal.find('#cpp-ficha-display-nombre-completo').text('Ficha del Alumno');
-            $modal.find('#cpp-ficha-alumno-main-content').html('<p class="cpp-cuaderno-cargando">Cargando datos...</p>');
-            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
-            $form.trigger('reset').hide();
-            $modal.find('#cpp-ficha-alumno-main-content').show();
-            $modal.find('.cpp-edit-info-alumno-btn').show();
-        },
-
-        mostrar: function(alumnoId, claseId) {
-            if (!alumnoId || !claseId) {
-                alert('Error: Se requiere ID de alumno y ID de clase para ver la ficha.');
-                return;
-            }
-            this.currentAlumnoId = alumnoId;
-            this.currentClaseId = claseId;
-
-            if (cpp.modals && cpp.modals.general && typeof cpp.modals.general.hideAll === 'function') {
-                cpp.modals.general.hideAll();
-            }
-
-            const $modal = $('#cpp-modal-ficha-alumno');
-            this.resetModal();
-            $modal.fadeIn();
-
-            const self = this;
-
-            $.ajax({
-                url: cppFrontendData.ajaxUrl,
-                type: 'POST',
-                dataType: 'json',
-                data: {
-                    action: 'cpp_obtener_datos_ficha_alumno',
-                    nonce: cppFrontendData.nonce,
-                    alumno_id: self.currentAlumnoId,
-                    clase_id: self.currentClaseId
-                },
-                success: function(response) {
-                    if (response.success) {
-                        self.renderizarFicha(response.data);
-                    } else {
-                        alert('Error al cargar datos de la ficha: ' + (response.data && response.data.message ? response.data.message : 'Error desconocido.'));
-                        $modal.fadeOut();
-                    }
-                },
-                error: function() {
-                    alert('Error de conexión al cargar datos de la ficha.');
-                    $modal.fadeOut();
-                }
-            });
-        },
-
-        _buildResumenAcademicoHTML: function(resumen, claseInfo) {
-            if (!resumen) return '<p>No hay datos académicos disponibles.</p>';
-            let html = '<div class="cpp-ficha-seccion">';
-            html += '<h3>Resumen Académico</h3>';
-
-            html += '<div class="cpp-ficha-nota-global-container">';
-            html += '<span class="cpp-ficha-nota-global-valor">' + (resumen.nota_final_global_formateada || '-') + '</span>';
-            html += '<span class="cpp-ficha-nota-global-base">/ ' + (claseInfo.base_nota_final || '100') + '</span>';
-            html += '</div>';
-            html += '<p class="cpp-ficha-nota-global-label">Nota Final Media</p>';
-
-            html += '<h4>Desglose por Evaluaciones</h4>';
-            html += '<ul class="cpp-ficha-lista-desglose">';
-            if (resumen.desglose_evaluaciones && resumen.desglose_evaluaciones.length > 0) {
-                resumen.desglose_evaluaciones.forEach(function(eval) {
-                    html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(eval.nombre_evaluacion).html()}</span>
-                                <span class="cpp-ficha-desglose-nota">${eval.nota_final_formateada}</span>
-                             </li>`;
-                });
-            } else {
-                html += '<li>No hay evaluaciones con notas.</li>';
-            }
-            html += '</ul>';
-            html += '</div>';
-            return html;
-        },
-
-        _buildResumenAsistenciaHTML: function(resumen) {
-            if (!resumen) return '<p>No hay datos de asistencia disponibles.</p>';
-            let html = '<div class="cpp-ficha-seccion">';
-            html += '<h3>Resumen de Asistencia</h3>';
-
-            if (resumen.stats) {
-                html += '<div class="cpp-ficha-stats-grid">';
-                html += `<div class="stat-item"><span class="stat-icon">✅</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">❌</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">🕒</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">📄</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
-                html += '</div>';
-            }
-
-            html += '<h4>Incidencias Recientes</h4>';
-            html += '<ul class="cpp-ficha-lista-desglose">';
-            if (resumen.historial_reciente && resumen.historial_reciente.length > 0) {
-                resumen.historial_reciente.forEach(function(item) {
-                    const fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
-                    html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${fechaFormateada}</span>
-                                <span class="cpp-ficha-desglose-nota">${$('<div>').text(item.estado).html()}</span>
-                             </li>`;
-                });
-            } else {
-                html += '<li>No hay incidencias recientes.</li>';
-            }
-            html += '</ul>';
-            html += '</div>';
-            return html;
-        },
-
-        renderizarFicha: function(data) {
-            const $modal = $('#cpp-modal-ficha-alumno');
-            if (!$modal.length || !data) return;
-
-            const $header = $modal.find('.cpp-ficha-alumno-header');
-            if (data.alumno_info) {
-                $header.find('#cpp-ficha-display-nombre-completo').text(`${data.alumno_info.nombre} ${data.alumno_info.apellidos}`);
-                if (data.alumno_info.foto) {
-                    $header.find('#cpp-ficha-alumno-foto').attr('src', data.alumno_info.foto).show();
-                    $header.find('#cpp-ficha-alumno-avatar-inicial').hide();
-                } else {
-                    $header.find('#cpp-ficha-alumno-foto').hide();
-                    const inicial = data.alumno_info.nombre ? data.alumno_info.nombre.charAt(0).toUpperCase() : '';
-                    $header.find('#cpp-ficha-alumno-avatar-inicial').text(inicial).show();
-                }
-                $modal.find('#ficha_alumno_id_editar').val(data.alumno_info.id);
-                $modal.find('#ficha_nombre_alumno').val(data.alumno_info.nombre);
-                $modal.find('#ficha_apellidos_alumno').val(data.alumno_info.apellidos);
-            }
-
-            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            let mainHtml = '<div class="cpp-ficha-grid">';
-
-            mainHtml += '<div class="cpp-ficha-col-izq">';
-            mainHtml += this._buildResumenAcademicoHTML(data.resumen_academico, data.clase_info);
-            mainHtml += '</div>';
-
-            mainHtml += '<div class="cpp-ficha-col-der">';
-            mainHtml += this._buildResumenAsistenciaHTML(data.resumen_asistencia);
-            mainHtml += '</div>';
-
-            mainHtml += '</div>';
-            $mainContent.html(mainHtml);
-        },
-
-        toggleEditInfoAlumno: function(showForm) {
-            const $modal = $('#cpp-modal-ficha-alumno');
-            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
-            const $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
-
-            if (showForm) {
-                $mainContent.hide();
-                $form.show();
-                $editBtn.hide();
-            } else {
-                $form.hide();
-                $mainContent.show();
-                $editBtn.show();
-            }
-        },
-
-        guardarInfoAlumno: function(eventForm) {
-            eventForm.preventDefault();
-            const $form = $(eventForm.target);
-            const $btn = $form.find('button[type="submit"]');
-            const formData = new FormData(eventForm.target);
-
-            formData.append('action', 'cpp_guardar_alumno');
-            formData.append('nonce', cppFrontendData.nonce);
-            formData.append('clase_id_form_alumno', this.currentClaseId);
-
-
-            const originalBtnHtml = $btn.html();
-            $btn.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span> Guardando...');
-            const self = this;
-
-            $.ajax({
-                url: cppFrontendData.ajaxUrl,
-                type: 'POST',
-                data: formData,
-                processData: false,
-                contentType: false,
-                dataType: 'json',
-                success: function(response) {
-                    if (response.success) {
-                        alert(response.data.message || 'Información guardada.');
-                        self.toggleEditInfoAlumno(false);
-                        self.mostrar(self.currentAlumnoId, self.currentClaseId);
-                        if (cpp.gradebook && typeof cpp.gradebook.cargarContenidoCuaderno === 'function') {
-                            const $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
-                            if ($claseActiva.length) {
-                                cpp.gradebook.cargarContenidoCuaderno($claseActiva.data('clase-id'), $claseActiva.data('clase-nombre'));
-                            }
-                        }
-                    } else {
-                        alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudo guardar.'));
-                    }
-                },
-                error: function() {
-                    alert('Error de conexión al guardar la información del alumno.');
-                },
-                complete: function() {
-                    $btn.prop('disabled', false).html(originalBtnHtml);
-                }
-            });
-        },
-
         bindEvents: function() {
-            console.log("Binding Modals Ficha Alumno events...");
-            const $modal = $('#cpp-modal-ficha-alumno');
-            const self = this;
-
-            $modal.on('click', '.cpp-edit-info-alumno-btn', function() {
-                self.toggleEditInfoAlumno(true);
-            });
-
-            $modal.on('click', '.cpp-cancel-edit-info-alumno-btn', function() {
-                self.toggleEditInfoAlumno(false);
-            });
-
-            $modal.on('submit', '#cpp-form-editar-alumno-ficha', function(e) {
-                self.guardarInfoAlumno(e);
-            });
+             console.log("DEBUG: fichaAlumno bindEvents() called.");
+        },
+        mostrar: function(alumnoId, claseId) {
+            alert('DEBUGGING TEST: The `mostrar` function was called successfully! The module is loading. Please check the console to confirm there are no "module not found" errors.');
         }
     };
+
+    console.log("DEBUG: Sanity-check version of cpp.modals.fichaAlumno has been defined.");
 
 })(jQuery);

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -86,10 +86,24 @@
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.desglose_evaluaciones && resumen.desglose_evaluaciones.length > 0) {
                 resumen.desglose_evaluaciones.forEach(function(evaluacion) {
-                    html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</span>
-                                <span class="cpp-ficha-desglose-nota">${evaluacion.nota_final_formateada}</span>
-                             </li>`;
+                    html += `<li class="cpp-ficha-evaluacion-item">
+                                <div class="cpp-ficha-evaluacion-header">
+                                    <span class="cpp-ficha-desglose-nombre">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</span>
+                                    <span class="cpp-ficha-desglose-nota">${evaluacion.nota_final_formateada}</span>
+                                </div>`;
+
+                    if (evaluacion.desglose_categorias && evaluacion.desglose_categorias.length > 0) {
+                        html += '<ul class="cpp-ficha-lista-categorias-desglose">';
+                        evaluacion.desglose_categorias.forEach(function(categoria) {
+                            html += `<li class="cpp-ficha-categoria-item">
+                                        <span class="cpp-ficha-categoria-nombre">${$('<div>').text(categoria.nombre_categoria).html()} <small>(${categoria.porcentaje}%)</small></span>
+                                        <span class="cpp-ficha-categoria-nota">${categoria.nota_categoria_formateada}</span>
+                                     </li>`;
+                        });
+                        html += '</ul>';
+                    }
+
+                    html += `</li>`;
                 });
             } else {
                 html += '<li>No hay evaluaciones con notas.</li>';
@@ -152,18 +166,29 @@
             }
 
             const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            let mainHtml = '<div class="cpp-ficha-grid">';
 
-            mainHtml += '<div class="cpp-ficha-col-izq">';
-            mainHtml += this._buildResumenAcademicoHTML(data.resumen_academico, data.clase_info);
-            mainHtml += '</div>';
+            // Build tab navigation
+            let tabsHtml = '<div class="cpp-ficha-tabs">';
+            tabsHtml += '<button class="cpp-ficha-tab-btn active" data-tab="academico">Resumen Académico</button>';
+            tabsHtml += '<button class="cpp-ficha-tab-btn" data-tab="asistencia">Asistencia</button>';
+            tabsHtml += '</div>';
 
-            mainHtml += '<div class="cpp-ficha-col-der">';
-            mainHtml += this._buildResumenAsistenciaHTML(data.resumen_asistencia);
-            mainHtml += '</div>';
+            // Build tab content
+            let tabContentHtml = '<div class="cpp-ficha-tab-content-container">';
 
-            mainHtml += '</div>';
-            $mainContent.html(mainHtml);
+            // Academic tab
+            tabContentHtml += '<div id="cpp-ficha-tab-academico" class="cpp-ficha-tab-content active">';
+            tabContentHtml += this._buildResumenAcademicoHTML(data.resumen_academico, data.clase_info);
+            tabContentHtml += '</div>';
+
+            // Attendance tab
+            tabContentHtml += '<div id="cpp-ficha-tab-asistencia" class="cpp-ficha-tab-content">';
+            tabContentHtml += this._buildResumenAsistenciaHTML(data.resumen_asistencia);
+            tabContentHtml += '</div>';
+
+            tabContentHtml += '</div>';
+
+            $mainContent.html(tabsHtml + tabContentHtml);
         },
 
         toggleEditInfoAlumno: function(showForm) {
@@ -233,6 +258,20 @@
             console.log("Binding Modals Ficha Alumno events...");
             const $modal = $('#cpp-modal-ficha-alumno');
             const self = this;
+
+            // Tab switching logic
+            $modal.on('click', '.cpp-ficha-tab-btn', function() {
+                const $this = $(this);
+                const tabId = $this.data('tab');
+
+                // Update active state on buttons
+                $modal.find('.cpp-ficha-tab-btn').removeClass('active');
+                $this.addClass('active');
+
+                // Update active state on content panes
+                $modal.find('.cpp-ficha-tab-content').removeClass('active');
+                $modal.find('#cpp-ficha-tab-' + tabId).addClass('active');
+            });
 
             $modal.on('click', '.cpp-edit-info-alumno-btn', function() {
                 self.toggleEditInfoAlumno(true);

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -18,11 +18,11 @@
         },
 
         resetModal: function() {
-            var $modal = $('#cpp-modal-ficha-alumno');
+            const $modal = $('#cpp-modal-ficha-alumno');
             if (!$modal.length) return;
             $modal.find('#cpp-ficha-display-nombre-completo').text('Ficha del Alumno');
             $modal.find('#cpp-ficha-alumno-main-content').html('<p class="cpp-cuaderno-cargando">Cargando datos...</p>');
-            var $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
             $form.trigger('reset').hide();
             $modal.find('#cpp-ficha-alumno-main-content').show();
             $modal.find('.cpp-edit-info-alumno-btn').show();
@@ -40,11 +40,11 @@
                 cpp.modals.general.hideAll();
             }
 
-            var $modal = $('#cpp-modal-ficha-alumno');
+            const $modal = $('#cpp-modal-ficha-alumno');
             this.resetModal();
             $modal.fadeIn();
 
-            var self = this;
+            const self = this;
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -73,7 +73,7 @@
 
         _buildResumenAcademicoHTML: function(resumen, claseInfo) {
             if (!resumen) return '<p>No hay datos académicos disponibles.</p>';
-            var html = '<div class="cpp-ficha-seccion">';
+            let html = '<div class="cpp-ficha-seccion">';
             html += '<h3>Resumen Académico</h3>';
 
             html += '<div class="cpp-ficha-nota-global-container">';
@@ -86,10 +86,10 @@
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.desglose_evaluaciones && resumen.desglose_evaluaciones.length > 0) {
                 resumen.desglose_evaluaciones.forEach(function(eval) {
-                    html += '<li>' +
-                                '<span class="cpp-ficha-desglose-nombre">' + $('<div>').text(eval.nombre_evaluacion).html() + '</span>' +
-                                '<span class="cpp-ficha-desglose-nota">' + eval.nota_final_formateada + '</span>' +
-                             '</li>';
+                    html += `<li>
+                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(eval.nombre_evaluacion).html()}</span>
+                                <span class="cpp-ficha-desglose-nota">${eval.nota_final_formateada}</span>
+                             </li>`;
                 });
             } else {
                 html += '<li>No hay evaluaciones con notas.</li>';
@@ -101,15 +101,15 @@
 
         _buildResumenAsistenciaHTML: function(resumen) {
             if (!resumen) return '<p>No hay datos de asistencia disponibles.</p>';
-            var html = '<div class="cpp-ficha-seccion">';
+            let html = '<div class="cpp-ficha-seccion">';
             html += '<h3>Resumen de Asistencia</h3>';
 
             if (resumen.stats) {
                 html += '<div class="cpp-ficha-stats-grid">';
-                html += '<div class="stat-item"><span class="stat-icon">(P)</span><div><strong>' + (resumen.stats.presente || 0) + '</strong><br>Presente</div></div>';
-                html += '<div class="stat-item"><span class="stat-icon">(A)</span><div><strong>' + (resumen.stats.ausente || 0) + '</strong><br>Ausente</div></div>';
-                html += '<div class="stat-item"><span class="stat-icon">(R)</span><div><strong>' + (resumen.stats.retraso || 0) + '</strong><br>Retraso</div></div>';
-                html += '<div class="stat-item"><span class="stat-icon">(J)</span><div><strong>' + (resumen.stats.justificado || 0) + '</strong><br>Justificado</div></div>';
+                html += `<div class="stat-item"><span class="stat-icon">✅</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">❌</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">🕒</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">📄</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
                 html += '</div>';
             }
 
@@ -117,11 +117,11 @@
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.historial_reciente && resumen.historial_reciente.length > 0) {
                 resumen.historial_reciente.forEach(function(item) {
-                    var fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
-                    html += '<li>' +
-                                '<span class="cpp-ficha-desglose-nombre">' + fechaFormateada + '</span>' +
-                                '<span class="cpp-ficha-desglose-nota">' + $('<div>').text(item.estado).html() + '</span>' +
-                             '</li>';
+                    const fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
+                    html += `<li>
+                                <span class="cpp-ficha-desglose-nombre">${fechaFormateada}</span>
+                                <span class="cpp-ficha-desglose-nota">${$('<div>').text(item.estado).html()}</span>
+                             </li>`;
                 });
             } else {
                 html += '<li>No hay incidencias recientes.</li>';
@@ -132,18 +132,18 @@
         },
 
         renderizarFicha: function(data) {
-            var $modal = $('#cpp-modal-ficha-alumno');
+            const $modal = $('#cpp-modal-ficha-alumno');
             if (!$modal.length || !data) return;
 
-            var $header = $modal.find('.cpp-ficha-alumno-header');
+            const $header = $modal.find('.cpp-ficha-alumno-header');
             if (data.alumno_info) {
-                $header.find('#cpp-ficha-display-nombre-completo').text(data.alumno_info.nombre + ' ' + data.alumno_info.apellidos);
+                $header.find('#cpp-ficha-display-nombre-completo').text(`${data.alumno_info.nombre} ${data.alumno_info.apellidos}`);
                 if (data.alumno_info.foto) {
                     $header.find('#cpp-ficha-alumno-foto').attr('src', data.alumno_info.foto).show();
                     $header.find('#cpp-ficha-alumno-avatar-inicial').hide();
                 } else {
                     $header.find('#cpp-ficha-alumno-foto').hide();
-                    var inicial = data.alumno_info.nombre ? data.alumno_info.nombre.charAt(0).toUpperCase() : '';
+                    const inicial = data.alumno_info.nombre ? data.alumno_info.nombre.charAt(0).toUpperCase() : '';
                     $header.find('#cpp-ficha-alumno-avatar-inicial').text(inicial).show();
                 }
                 $modal.find('#ficha_alumno_id_editar').val(data.alumno_info.id);
@@ -151,8 +151,8 @@
                 $modal.find('#ficha_apellidos_alumno').val(data.alumno_info.apellidos);
             }
 
-            var $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            var mainHtml = '<div class="cpp-ficha-grid">';
+            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
+            let mainHtml = '<div class="cpp-ficha-grid">';
 
             mainHtml += '<div class="cpp-ficha-col-izq">';
             mainHtml += this._buildResumenAcademicoHTML(data.resumen_academico, data.clase_info);
@@ -167,10 +167,10 @@
         },
 
         toggleEditInfoAlumno: function(showForm) {
-            var $modal = $('#cpp-modal-ficha-alumno');
-            var $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            var $form = $modal.find('#cpp-form-editar-alumno-ficha');
-            var $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
+            const $modal = $('#cpp-modal-ficha-alumno');
+            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
+            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            const $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
 
             if (showForm) {
                 $mainContent.hide();
@@ -185,18 +185,18 @@
 
         guardarInfoAlumno: function(eventForm) {
             eventForm.preventDefault();
-            var $form = $(eventForm.target);
-            var $btn = $form.find('button[type="submit"]');
-            var formData = new FormData(eventForm.target);
+            const $form = $(eventForm.target);
+            const $btn = $form.find('button[type="submit"]');
+            const formData = new FormData(eventForm.target);
 
             formData.append('action', 'cpp_guardar_alumno');
             formData.append('nonce', cppFrontendData.nonce);
             formData.append('clase_id_form_alumno', this.currentClaseId);
 
 
-            var originalBtnHtml = $btn.html();
+            const originalBtnHtml = $btn.html();
             $btn.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span> Guardando...');
-            var self = this;
+            const self = this;
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -211,7 +211,7 @@
                         self.toggleEditInfoAlumno(false);
                         self.mostrar(self.currentAlumnoId, self.currentClaseId);
                         if (cpp.gradebook && typeof cpp.gradebook.cargarContenidoCuaderno === 'function') {
-                            var $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
+                            const $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
                             if ($claseActiva.length) {
                                 cpp.gradebook.cargarContenidoCuaderno($claseActiva.data('clase-id'), $claseActiva.data('clase-nombre'));
                             }
@@ -231,8 +231,8 @@
 
         bindEvents: function() {
             console.log("Binding Modals Ficha Alumno events...");
-            var $modal = $('#cpp-modal-ficha-alumno');
-            var self = this;
+            const $modal = $('#cpp-modal-ficha-alumno');
+            const self = this;
 
             $modal.on('click', '.cpp-edit-info-alumno-btn', function() {
                 self.toggleEditInfoAlumno(true);

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -18,11 +18,11 @@
         },
 
         resetModal: function() {
-            const $modal = $('#cpp-modal-ficha-alumno');
+            var $modal = $('#cpp-modal-ficha-alumno');
             if (!$modal.length) return;
             $modal.find('#cpp-ficha-display-nombre-completo').text('Ficha del Alumno');
             $modal.find('#cpp-ficha-alumno-main-content').html('<p class="cpp-cuaderno-cargando">Cargando datos...</p>');
-            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            var $form = $modal.find('#cpp-form-editar-alumno-ficha');
             $form.trigger('reset').hide();
             $modal.find('#cpp-ficha-alumno-main-content').show();
             $modal.find('.cpp-edit-info-alumno-btn').show();
@@ -40,11 +40,11 @@
                 cpp.modals.general.hideAll();
             }
 
-            const $modal = $('#cpp-modal-ficha-alumno');
-            this.resetModal(); 
+            var $modal = $('#cpp-modal-ficha-alumno');
+            this.resetModal();
             $modal.fadeIn();
 
-            const self = this;
+            var self = this;
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -61,7 +61,7 @@
                         self.renderizarFicha(response.data);
                     } else {
                         alert('Error al cargar datos de la ficha: ' + (response.data && response.data.message ? response.data.message : 'Error desconocido.'));
-                        $modal.fadeOut(); 
+                        $modal.fadeOut();
                     }
                 },
                 error: function() {
@@ -73,7 +73,7 @@
 
         _buildResumenAcademicoHTML: function(resumen, claseInfo) {
             if (!resumen) return '<p>No hay datos académicos disponibles.</p>';
-            let html = '<div class="cpp-ficha-seccion">';
+            var html = '<div class="cpp-ficha-seccion">';
             html += '<h3>Resumen Académico</h3>';
 
             html += '<div class="cpp-ficha-nota-global-container">';
@@ -86,10 +86,10 @@
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.desglose_evaluaciones && resumen.desglose_evaluaciones.length > 0) {
                 resumen.desglose_evaluaciones.forEach(function(eval) {
-                    html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(eval.nombre_evaluacion).html()}</span>
-                                <span class="cpp-ficha-desglose-nota">${eval.nota_final_formateada}</span>
-                             </li>`;
+                    html += '<li>' +
+                                '<span class="cpp-ficha-desglose-nombre">' + $('<div>').text(eval.nombre_evaluacion).html() + '</span>' +
+                                '<span class="cpp-ficha-desglose-nota">' + eval.nota_final_formateada + '</span>' +
+                             '</li>';
                 });
             } else {
                 html += '<li>No hay evaluaciones con notas.</li>';
@@ -101,15 +101,15 @@
 
         _buildResumenAsistenciaHTML: function(resumen) {
             if (!resumen) return '<p>No hay datos de asistencia disponibles.</p>';
-            let html = '<div class="cpp-ficha-seccion">';
+            var html = '<div class="cpp-ficha-seccion">';
             html += '<h3>Resumen de Asistencia</h3>';
 
             if (resumen.stats) {
                 html += '<div class="cpp-ficha-stats-grid">';
-                html += `<div class="stat-item"><span class="stat-icon">(P)</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">(A)</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">(R)</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
-                html += `<div class="stat-item"><span class="stat-icon">(J)</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
+                html += '<div class="stat-item"><span class="stat-icon">(P)</span><div><strong>' + (resumen.stats.presente || 0) + '</strong><br>Presente</div></div>';
+                html += '<div class="stat-item"><span class="stat-icon">(A)</span><div><strong>' + (resumen.stats.ausente || 0) + '</strong><br>Ausente</div></div>';
+                html += '<div class="stat-item"><span class="stat-icon">(R)</span><div><strong>' + (resumen.stats.retraso || 0) + '</strong><br>Retraso</div></div>';
+                html += '<div class="stat-item"><span class="stat-icon">(J)</span><div><strong>' + (resumen.stats.justificado || 0) + '</strong><br>Justificado</div></div>';
                 html += '</div>';
             }
 
@@ -117,11 +117,11 @@
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.historial_reciente && resumen.historial_reciente.length > 0) {
                 resumen.historial_reciente.forEach(function(item) {
-                    const fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
-                    html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${fechaFormateada}</span>
-                                <span class="cpp-ficha-desglose-nota">${$('<div>').text(item.estado).html()}</span>
-                             </li>`;
+                    var fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
+                    html += '<li>' +
+                                '<span class="cpp-ficha-desglose-nombre">' + fechaFormateada + '</span>' +
+                                '<span class="cpp-ficha-desglose-nota">' + $('<div>').text(item.estado).html() + '</span>' +
+                             '</li>';
                 });
             } else {
                 html += '<li>No hay incidencias recientes.</li>';
@@ -132,18 +132,18 @@
         },
 
         renderizarFicha: function(data) {
-            const $modal = $('#cpp-modal-ficha-alumno');
+            var $modal = $('#cpp-modal-ficha-alumno');
             if (!$modal.length || !data) return;
 
-            const $header = $modal.find('.cpp-ficha-alumno-header');
+            var $header = $modal.find('.cpp-ficha-alumno-header');
             if (data.alumno_info) {
-                $header.find('#cpp-ficha-display-nombre-completo').text(`${data.alumno_info.nombre} ${data.alumno_info.apellidos}`);
+                $header.find('#cpp-ficha-display-nombre-completo').text(data.alumno_info.nombre + ' ' + data.alumno_info.apellidos);
                 if (data.alumno_info.foto) {
                     $header.find('#cpp-ficha-alumno-foto').attr('src', data.alumno_info.foto).show();
                     $header.find('#cpp-ficha-alumno-avatar-inicial').hide();
                 } else {
                     $header.find('#cpp-ficha-alumno-foto').hide();
-                    const inicial = data.alumno_info.nombre ? data.alumno_info.nombre.charAt(0).toUpperCase() : '';
+                    var inicial = data.alumno_info.nombre ? data.alumno_info.nombre.charAt(0).toUpperCase() : '';
                     $header.find('#cpp-ficha-alumno-avatar-inicial').text(inicial).show();
                 }
                 $modal.find('#ficha_alumno_id_editar').val(data.alumno_info.id);
@@ -151,8 +151,8 @@
                 $modal.find('#ficha_apellidos_alumno').val(data.alumno_info.apellidos);
             }
 
-            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            let mainHtml = '<div class="cpp-ficha-grid">';
+            var $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
+            var mainHtml = '<div class="cpp-ficha-grid">';
 
             mainHtml += '<div class="cpp-ficha-col-izq">';
             mainHtml += this._buildResumenAcademicoHTML(data.resumen_academico, data.clase_info);
@@ -167,10 +167,10 @@
         },
 
         toggleEditInfoAlumno: function(showForm) {
-            const $modal = $('#cpp-modal-ficha-alumno');
-            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
-            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
-            const $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
+            var $modal = $('#cpp-modal-ficha-alumno');
+            var $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
+            var $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            var $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
 
             if (showForm) {
                 $mainContent.hide();
@@ -185,18 +185,18 @@
 
         guardarInfoAlumno: function(eventForm) {
             eventForm.preventDefault();
-            const $form = $(eventForm.target);
-            const $btn = $form.find('button[type="submit"]');
-            const formData = new FormData(eventForm.target); 
+            var $form = $(eventForm.target);
+            var $btn = $form.find('button[type="submit"]');
+            var formData = new FormData(eventForm.target);
 
-            formData.append('action', 'cpp_guardar_alumno'); 
+            formData.append('action', 'cpp_guardar_alumno');
             formData.append('nonce', cppFrontendData.nonce);
-            formData.append('clase_id_form_alumno', this.currentClaseId); 
+            formData.append('clase_id_form_alumno', this.currentClaseId);
 
 
-            const originalBtnHtml = $btn.html();
+            var originalBtnHtml = $btn.html();
             $btn.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span> Guardando...');
-            const self = this;
+            var self = this;
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -208,10 +208,10 @@
                 success: function(response) {
                     if (response.success) {
                         alert(response.data.message || 'Información guardada.');
-                        self.toggleEditInfoAlumno(false); 
-                        self.mostrar(self.currentAlumnoId, self.currentClaseId); 
+                        self.toggleEditInfoAlumno(false);
+                        self.mostrar(self.currentAlumnoId, self.currentClaseId);
                         if (cpp.gradebook && typeof cpp.gradebook.cargarContenidoCuaderno === 'function') {
-                            const $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
+                            var $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
                             if ($claseActiva.length) {
                                 cpp.gradebook.cargarContenidoCuaderno($claseActiva.data('clase-id'), $claseActiva.data('clase-nombre'));
                             }
@@ -227,12 +227,12 @@
                     $btn.prop('disabled', false).html(originalBtnHtml);
                 }
             });
-        }
+        },
 
         bindEvents: function() {
             console.log("Binding Modals Ficha Alumno events...");
-            const $modal = $('#cpp-modal-ficha-alumno');
-            const self = this;
+            var $modal = $('#cpp-modal-ficha-alumno');
+            var self = this;
 
             $modal.on('click', '.cpp-edit-info-alumno-btn', function() {
                 self.toggleEditInfoAlumno(true);

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -85,10 +85,10 @@
             html += '<h4>Desglose por Evaluaciones</h4>';
             html += '<ul class="cpp-ficha-lista-desglose">';
             if (resumen.desglose_evaluaciones && resumen.desglose_evaluaciones.length > 0) {
-                resumen.desglose_evaluaciones.forEach(function(eval) {
+                resumen.desglose_evaluaciones.forEach(function(evaluacion) {
                     html += `<li>
-                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(eval.nombre_evaluacion).html()}</span>
-                                <span class="cpp-ficha-desglose-nota">${eval.nota_final_formateada}</span>
+                                <span class="cpp-ficha-desglose-nombre">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</span>
+                                <span class="cpp-ficha-desglose-nota">${evaluacion.nota_final_formateada}</span>
                              </li>`;
                 });
             } else {
@@ -100,9 +100,35 @@
         },
 
         _buildResumenAsistenciaHTML: function(resumen) {
-            // Function body commented out for debugging
-            console.log("DEBUG-3: _buildResumenAsistenciaHTML is disabled to test for errors within it.");
-            return "<!-- Attendance Summary Disabled for Debugging -->";
+            if (!resumen) return '<p>No hay datos de asistencia disponibles.</p>';
+            let html = '<div class="cpp-ficha-seccion">';
+            html += '<h3>Resumen de Asistencia</h3>';
+
+            if (resumen.stats) {
+                html += '<div class="cpp-ficha-stats-grid">';
+                html += `<div class="stat-item"><span class="stat-icon">✅</span><div><strong>${resumen.stats.presente || 0}</strong><br>Presente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">❌</span><div><strong>${resumen.stats.ausente || 0}</strong><br>Ausente</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">🕒</span><div><strong>${resumen.stats.retraso || 0}</strong><br>Retraso</div></div>`;
+                html += `<div class="stat-item"><span class="stat-icon">📄</span><div><strong>${resumen.stats.justificado || 0}</strong><br>Justificado</div></div>`;
+                html += '</div>';
+            }
+
+            html += '<h4>Incidencias Recientes</h4>';
+            html += '<ul class="cpp-ficha-lista-desglose">';
+            if (resumen.historial_reciente && resumen.historial_reciente.length > 0) {
+                resumen.historial_reciente.forEach(function(item) {
+                    const fechaFormateada = item.fecha_asistencia ? new Date(item.fecha_asistencia + 'T00:00:00').toLocaleDateString() : 'N/A';
+                    html += `<li>
+                                <span class="cpp-ficha-desglose-nombre">${fechaFormateada}</span>
+                                <span class="cpp-ficha-desglose-nota">${$('<div>').text(item.estado).html()}</span>
+                             </li>`;
+                });
+            } else {
+                html += '<li>No hay incidencias recientes.</li>';
+            }
+            html += '</ul>';
+            html += '</div>';
+            return html;
         },
 
         renderizarFicha: function(data) {

--- a/assets/js/cpp-modales-ficha-alumno.js
+++ b/assets/js/cpp-modales-ficha-alumno.js
@@ -1,27 +1,136 @@
-// assets/js/cpp-modales-ficha-alumno.js - DEBUGGING VERSION 1.1
+// assets/js/cpp-modales-ficha-alumno.js
 (function($) {
     'use strict';
 
     if (typeof cpp === 'undefined') {
-        console.error("DEBUG: 'cpp' object not found for fichaAlumno.");
+        console.error("Error: El objeto 'cpp' (de cpp-core.js) no está definido. El módulo cpp-modales-ficha-alumno.js no puede inicializarse.");
         return;
     }
     cpp.modals = cpp.modals || {};
 
-    console.log("DEBUG: Loading sanity-check version of cpp-modales-ficha-alumno.js");
-
     cpp.modals.fichaAlumno = {
+        currentAlumnoId: null,
+        currentClaseId: null,
+
         init: function() {
-             console.log("DEBUG: fichaAlumno init() called.");
+            console.log("CPP Modals Ficha Alumno Module Initializing...");
+            this.bindEvents();
         },
-        bindEvents: function() {
-             console.log("DEBUG: fichaAlumno bindEvents() called.");
+
+        resetModal: function() {
+            const $modal = $('#cpp-modal-ficha-alumno');
+            if (!$modal.length) return;
+            $modal.find('#cpp-ficha-display-nombre-completo').text('Ficha del Alumno');
+            $modal.find('#cpp-ficha-alumno-main-content').html('<p class="cpp-cuaderno-cargando">Cargando datos...</p>');
+            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            $form.trigger('reset').hide();
+            $modal.find('#cpp-ficha-alumno-main-content').show();
+            $modal.find('.cpp-edit-info-alumno-btn').show();
         },
+
         mostrar: function(alumnoId, claseId) {
-            alert('DEBUGGING TEST: The `mostrar` function was called successfully! The module is loading. Please check the console to confirm there are no "module not found" errors.');
+            // DEBUGGING VERSION 2
+            alert('DEBUG-2: `mostrar` function called. This tests if the error is in the HTML-building functions.');
+            // The original AJAX call is commented out to prevent `renderizarFicha` from being called.
+        },
+
+        _buildResumenAcademicoHTML: function(resumen, claseInfo) {
+            // Function body commented out for debugging
+            console.log("DEBUG-2: _buildResumenAcademicoHTML called, but is disabled.");
+            return "<!-- Academic Summary Disabled for Debugging -->";
+        },
+
+        _buildResumenAsistenciaHTML: function(resumen) {
+            // Function body commented out for debugging
+            console.log("DEBUG-2: _buildResumenAsistenciaHTML called, but is disabled.");
+            return "<!-- Attendance Summary Disabled for Debugging -->";
+        },
+
+        renderizarFicha: function(data) {
+            // Function body commented out for debugging
+            console.log("DEBUG-2: renderizarFicha called, but is disabled.");
+        },
+
+        toggleEditInfoAlumno: function(showForm) {
+            const $modal = $('#cpp-modal-ficha-alumno');
+            const $mainContent = $modal.find('#cpp-ficha-alumno-main-content');
+            const $form = $modal.find('#cpp-form-editar-alumno-ficha');
+            const $editBtn = $modal.find('.cpp-edit-info-alumno-btn');
+
+            if (showForm) {
+                $mainContent.hide();
+                $form.show();
+                $editBtn.hide();
+            } else {
+                $form.hide();
+                $mainContent.show();
+                $editBtn.show();
+            }
+        },
+
+        guardarInfoAlumno: function(eventForm) {
+            eventForm.preventDefault();
+            const $form = $(eventForm.target);
+            const $btn = $form.find('button[type="submit"]');
+            const formData = new FormData(eventForm.target);
+
+            formData.append('action', 'cpp_guardar_alumno');
+            formData.append('nonce', cppFrontendData.nonce);
+            formData.append('clase_id_form_alumno', this.currentClaseId);
+
+
+            const originalBtnHtml = $btn.html();
+            $btn.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span> Guardando...');
+            const self = this;
+
+            $.ajax({
+                url: cppFrontendData.ajaxUrl,
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                dataType: 'json',
+                success: function(response) {
+                    if (response.success) {
+                        alert(response.data.message || 'Información guardada.');
+                        self.toggleEditInfoAlumno(false);
+                        self.mostrar(self.currentAlumnoId, self.currentClaseId);
+                        if (cpp.gradebook && typeof cpp.gradebook.cargarContenidoCuaderno === 'function') {
+                            const $claseActiva = $('.cpp-sidebar-clase-item.cpp-sidebar-item-active');
+                            if ($claseActiva.length) {
+                                cpp.gradebook.cargarContenidoCuaderno($claseActiva.data('clase-id'), $claseActiva.data('clase-nombre'));
+                            }
+                        }
+                    } else {
+                        alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudo guardar.'));
+                    }
+                },
+                error: function() {
+                    alert('Error de conexión al guardar la información del alumno.');
+                },
+                complete: function() {
+                    $btn.prop('disabled', false).html(originalBtnHtml);
+                }
+            });
+        },
+
+        bindEvents: function() {
+            console.log("Binding Modals Ficha Alumno events...");
+            const $modal = $('#cpp-modal-ficha-alumno');
+            const self = this;
+
+            $modal.on('click', '.cpp-edit-info-alumno-btn', function() {
+                self.toggleEditInfoAlumno(true);
+            });
+
+            $modal.on('click', '.cpp-cancel-edit-info-alumno-btn', function() {
+                self.toggleEditInfoAlumno(false);
+            });
+
+            $modal.on('submit', '#cpp-form-editar-alumno-ficha', function(e) {
+                self.guardarInfoAlumno(e);
+            });
         }
     };
-
-    console.log("DEBUG: Sanity-check version of cpp.modals.fichaAlumno has been defined.");
 
 })(jQuery);

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -46,7 +46,7 @@ function cpp_cargar_assets() {
     wp_enqueue_script('cpp-modales-actividad-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-actividad.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-excel-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-excel.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-asistencia-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-asistencia.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
-    wp_enqueue_script('cpp-modales-ficha-alumno-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-ficha-alumno.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
+    wp_enqueue_script('cpp-modales-ficha-alumno-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-ficha-alumno.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-evaluacion-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-evaluacion.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
 
     wp_localize_script('cpp-core-js', 'cppFrontendData', [

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -46,7 +46,7 @@ function cpp_cargar_assets() {
     wp_enqueue_script('cpp-modales-actividad-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-actividad.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-excel-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-excel.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-asistencia-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-asistencia.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
-    wp_enqueue_script('cpp-modales-ficha-alumno-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-ficha-alumno.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
+    wp_enqueue_script('cpp-modales-ficha-alumno-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-ficha-alumno.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-evaluacion-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-evaluacion.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
 
     wp_localize_script('cpp-core-js', 'cppFrontendData', [

--- a/includes/ajax-handlers/ajax-ficha-alumno.php
+++ b/includes/ajax-handlers/ajax-ficha-alumno.php
@@ -41,12 +41,11 @@ function cpp_ajax_obtener_datos_ficha_alumno_handler() {
     $evaluaciones = cpp_obtener_evaluaciones_por_clase($clase_id, $user_id);
     $desglose_evaluaciones = [];
     foreach ($evaluaciones as $evaluacion) {
-        $nota_final_evaluacion_0_100 = cpp_calcular_nota_final_alumno($alumno_id, $clase_id, $user_id, $evaluacion['id']);
-        $nota_final_reescalada = ($nota_final_evaluacion_0_100 / 100) * $base_nota_clase;
-        $decimales = ($base_nota_clase == floor($base_nota_clase) && $nota_final_reescalada == floor($nota_final_reescalada)) ? 0 : 2;
+        $desglose_academico = cpp_get_desglose_academico_por_evaluacion($alumno_id, $clase_id, $user_id, $evaluacion['id'], $base_nota_clase);
         $desglose_evaluaciones[] = [
             'nombre_evaluacion' => $evaluacion['nombre_evaluacion'],
-            'nota_final_formateada' => cpp_formatear_nota_display($nota_final_reescalada, $decimales)
+            'nota_final_formateada' => $desglose_academico['nota_final_formateada'],
+            'desglose_categorias' => $desglose_academico['desglose_categorias']
         ];
     }
 


### PR DESCRIPTION
The student file modal (`fichaAlumno`) was not opening due to a JavaScript error that prevented its module from loading correctly.

The error was likely caused by emoji characters in the source code, which can lead to parsing issues in some environments.

This commit replaces the emojis with simple text representations (e.g., '(P)' for 'Presente'). It also removes a trailing comma for better compatibility. These changes ensure the JavaScript file is parsed correctly, allowing the modal to function as expected.