### PR TITLE
feat: Add "Configuración" tab and fix modal positioning

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -414,11 +414,36 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
 .cpp-sidebar-overlay.cpp-sidebar-visible { display: block; }
 
 /* Estilos Generales de Modales */
-.cpp-modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); z-index: 1050; overflow-y: auto; padding: 30px 15px; }
-.cpp-modal-content { background: #fff; border-radius: 8px; box-shadow: 0 4px 23px 5px rgba(0,0,0,0.2), 0 2px 6px rgba(0,0,0,0.15); max-width: 560px; margin: 0 auto; padding: 24px; position: relative; font-size: 14px; }
+.cpp-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.6);
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.cpp-modal-content {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 23px 5px rgba(0,0,0,0.2), 0 2px 6px rgba(0,0,0,0.15);
+    max-width: 560px;
+    width: 90%;
+    padding: 24px;
+    position: relative;
+    font-size: 14px;
+    max-height: 90vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
 .cpp-modal-close { position: absolute; top: 12px; right: 12px; font-size: 24px; color: #5f6368; cursor: pointer; line-height: 1; padding: 4px; border-radius: 50%; }
 .cpp-modal-close:hover { color: #202124; background-color: rgba(0,0,0,0.05); }
-.cpp-modal-content h2 { margin-top: 0; margin-bottom: 24px; font-size: 20px; font-weight: 500; color: #202124; }
+.cpp-modal-content h2 { margin-top: 0; margin-bottom: 24px; font-size: 20px; font-weight: 500; color: #202124; flex-shrink: 0; }
 .cpp-form-group { margin-bottom: 20px; }
 .cpp-form-group label { display: block; margin-bottom: 8px; font-weight: 500; font-size: 14px; color: #3c4043; }
 .cpp-form-group input[type="text"], .cpp-form-group input[type="number"], .cpp-form-group input[type="date"], .cpp-form-group input[type="color"], .cpp-form-group textarea, .cpp-form-group select {
@@ -1182,6 +1207,79 @@ body.cpp-no-text-select {
 }
 
 /* --- FIN: Estilos para Menú de Usuario --- */
+
+/* --- INICIO: Estilos para la Pestaña de Configuración --- */
+.cpp-config-container {
+    display: flex;
+    height: 100%;
+}
+.cpp-config-sidebar {
+    width: 220px;
+    background-color: #f8f9fa;
+    border-right: 1px solid #e0e0e0;
+    padding: 20px 0;
+    flex-shrink: 0;
+}
+.cpp-config-tab-link {
+    display: flex;
+    align-items: center;
+    padding: 12px 24px;
+    text-decoration: none;
+    color: #3c4043;
+    font-size: 14px;
+    font-weight: 500;
+    border-left: 3px solid transparent;
+}
+.cpp-config-tab-link:hover {
+    background-color: #f1f3f4;
+}
+.cpp-config-tab-link.active {
+    background-color: #e8f0fe;
+    color: #1a73e8;
+    border-left-color: #1a73e8;
+}
+.cpp-config-tab-link .dashicons {
+    margin-right: 16px;
+    font-size: 20px;
+}
+.cpp-config-content-area {
+    flex-grow: 1;
+    padding: 30px;
+    overflow-y: auto;
+}
+.cpp-config-tab-content {
+    display: none;
+}
+.cpp-config-tab-content.active {
+    display: block;
+}
+.cpp-config-content-area h2 {
+    font-size: 24px;
+    font-weight: 500;
+    color: #202124;
+    margin-top: 0;
+    margin-bottom: 24px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #e0e0e0;
+}
+.cpp-config-content-area h3 {
+    font-size: 18px;
+    font-weight: 500;
+    margin-top: 24px;
+    margin-bottom: 16px;
+}
+.cpp-config-actions {
+    display: flex;
+    justify-content: flex-start;
+    gap: 10px;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid #e0e0e0;
+}
+#cpp-config-tab-evaluaciones .cpp-tabs-container {
+    margin-top: 20px;
+}
+/* --- FIN: Estilos para la Pestaña de Configuración --- */
 
 /* --- INICIO: Rediseño Celda A1 --- */
 

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -488,9 +488,18 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
 .cpp-categorias-list { margin-bottom: 20px; }
 .cpp-categorias-list h4, .cpp-form-categoria-container h4 { font-size: 16px; margin-bottom: 10px; font-weight: 500; }
 .cpp-categorias-list ul { list-style: none; padding: 0; margin: 0; }
-.cpp-categorias-list li { padding: 8px 0; border-bottom: 1px solid #eee; display: flex; justify-content: space-between; align-items: center; font-size: 14px; font-weight: normal; }
+.cpp-categorias-list li { padding: 12px 8px; border-bottom: 1px solid #eee; display: flex; justify-content: space-between; align-items: center; font-size: 15px; font-weight: normal; }
 .cpp-categorias-list li:last-child { border-bottom: none; }
-.cpp-categorias-list li strong { margin-left: 5px; font-weight: 500; }
+.cpp-categorias-list li strong { margin-left: 8px; font-weight: 500; }
+
+#cpp-gestion-categorias-wrapper .cpp-form-group {
+    margin-bottom: 24px;
+}
+
+#cpp-gestion-categorias-wrapper .cpp-form-group label {
+    font-size: 15px;
+    margin-bottom: 10px;
+}
 
 .cpp-categoria-actions { display: flex; align-items: center; gap: 5px; margin-left: auto; }
 .cpp-btn-editar-categoria .dashicons, .cpp-btn-eliminar-categoria .dashicons { font-size: 18px !important; }
@@ -1246,6 +1255,7 @@ body.cpp-no-text-select {
     flex-grow: 1;
     padding: 30px;
     overflow-y: auto;
+    padding-bottom: 60px; /* Añadir espacio en la parte inferior */
 }
 .cpp-config-tab-content {
     display: none;

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -186,8 +186,9 @@
                         this.handleConfigTabClick(null, 'clase');
                         $form.find('#nombre_clase_config').focus();
 
-                        // Cargar datos en las otras pestañas
-                        this.cargarContenidoEvaluaciones(claseId);
+                        // Cargar datos en las otras pestañas, usando los datos de la respuesta principal
+                        this.renderEvaluacionesList(clase.evaluaciones, clase.id);
+                        this.renderPonderacionesContainer(clase.evaluaciones);
 
                     } else {
                         alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudieron cargar datos.'));
@@ -380,50 +381,21 @@
             $(`#cpp-config-tab-${tabId}`).addClass('active');
         },
 
-        cargarContenidoEvaluaciones: function(claseId) {
-            const self = this;
-            const $evaluacionesContainer = $('#cpp-config-evaluaciones-container');
+        renderPonderacionesContainer: function(evaluaciones) {
             const $ponderacionesContainer = $('#cpp-config-ponderaciones-container');
-
-            $evaluacionesContainer.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
-            $ponderacionesContainer.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
-
-            $.ajax({
-                url: cppFrontendData.ajaxUrl,
-                type: 'POST',
-                dataType: 'json',
-                data: { action: 'cpp_obtener_evaluaciones', nonce: cppFrontendData.nonce, clase_id: claseId },
-                success: function(response) {
-                    if (response.success) {
-                        // Renderizar lista de evaluaciones
-                        self.renderEvaluacionesList(response.data.evaluaciones, claseId);
-
-                        // Renderizar sección de ponderaciones
-                        if (response.data.evaluaciones && response.data.evaluaciones.length > 0) {
-                            let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
-                            contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
-                            contentHtml += '<option value="">-- Selecciona --</option>';
-                            response.data.evaluaciones.forEach(function(evaluacion) {
-                                contentHtml += `<option value="${evaluacion.id}">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</option>`;
-                            });
-                            contentHtml += '</select></div><hr>';
-                            contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
-                            $ponderacionesContainer.html(contentHtml);
-                        } else {
-                            $ponderacionesContainer.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la sección de arriba.</p>');
-                        }
-                    } else {
-                        const errorMsg = '<p class="cpp-error-message">Error al cargar las evaluaciones.</p>';
-                        $evaluacionesContainer.html(errorMsg);
-                        $ponderacionesContainer.html(errorMsg);
-                    }
-                },
-                error: function() {
-                    const errorMsg = '<p class="cpp-error-message">Error de conexión.</p>';
-                    $evaluacionesContainer.html(errorMsg);
-                    $ponderacionesContainer.html(errorMsg);
-                }
-            });
+            if (evaluaciones && evaluaciones.length > 0) {
+                let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
+                contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
+                contentHtml += '<option value="">-- Selecciona --</option>';
+                evaluaciones.forEach(function(evaluacion) {
+                    contentHtml += `<option value="${evaluacion.id}">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</option>`;
+                });
+                contentHtml += '</select></div><hr>';
+                contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
+                $ponderacionesContainer.html(contentHtml);
+            } else {
+                $ponderacionesContainer.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la sección de arriba.</p>');
+            }
         },
         
         renderEvaluacionesList: function(evaluaciones, claseId) {

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -142,10 +142,8 @@
             
             if (!claseId) { alert('Error: No se pudo identificar la clase para editar.'); return; }
             
-            // Cambiar a la pestaña de configuración
             $('.cpp-main-tab-link[data-tab="configuracion"]').trigger('click');
 
-            // Cerrar el sidebar si está abierto
             if (cpp.sidebar && cpp.sidebar.isSidebarVisible) {
                 cpp.sidebar.toggle();
             }
@@ -157,6 +155,8 @@
             this.currentClaseIdForConfig = claseId;
 
             $('#cpp-opcion-clase-ejemplo-container').hide();
+
+            const self = this;
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl, type: 'POST', dataType: 'json',
@@ -186,9 +186,9 @@
                         this.handleConfigTabClick(null, 'clase');
                         $form.find('#nombre_clase_config').focus();
 
-                        // Cargar datos en las otras pestañas, usando los datos de la respuesta principal
-                        this.renderEvaluacionesList(clase.evaluaciones, clase.id);
-                        this.renderPonderacionesContainer(clase.evaluaciones);
+                        // Cargar datos en las otras pestañas
+                        self.refreshEvaluacionesList(clase.id, clase.evaluaciones);
+                        self.loadPonderacionesTab(clase.id, clase.evaluaciones);
 
                     } else {
                         alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudieron cargar datos.'));
@@ -381,8 +381,9 @@
             $(`#cpp-config-tab-${tabId}`).addClass('active');
         },
 
-        renderPonderacionesContainer: function(evaluaciones) {
-            const $ponderacionesContainer = $('#cpp-config-ponderaciones-container');
+
+        loadPonderacionesTab: function(claseId, evaluaciones) {
+            const $container = $('#cpp-config-ponderaciones-container');
             if (evaluaciones && evaluaciones.length > 0) {
                 let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
                 contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
@@ -392,12 +393,16 @@
                 });
                 contentHtml += '</select></div><hr>';
                 contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
-                $ponderacionesContainer.html(contentHtml);
+                $container.html(contentHtml);
             } else {
-                $ponderacionesContainer.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la sección de arriba.</p>');
+                $container.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la sección de arriba.</p>');
             }
         },
         
+        refreshEvaluacionesList: function(claseId, evaluaciones) {
+            this.renderEvaluacionesList(evaluaciones, claseId);
+        },
+
         renderEvaluacionesList: function(evaluaciones, claseId) {
             const $container = $('#cpp-config-evaluaciones-container');
             let html = '<h4>Gestionar Evaluaciones</h4>';

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -1,30 +1,29 @@
-// assets/js/cpp-modales-clase.js (v1.5.2 - FINAL)
+// assets/js/cpp-configuracion.js
 
 (function($) {
     'use strict';
 
     if (typeof cpp === 'undefined') {
-        console.error("Error: El objeto 'cpp' (de cpp-core.js) no está definido. El módulo cpp-modales-clase.js no puede inicializarse.");
+        console.error("Error: El objeto 'cpp' (de cpp-core.js) no está definido. El módulo cpp-configuracion.js no puede inicializarse.");
         return;
     }
-    cpp.modals = cpp.modals || {};
-
-    cpp.modals.clase = {
-        currentClaseIdForModal: null,
+    cpp.config = {
+        currentClaseIdForConfig: null,
 
         init: function() {
-            console.log("CPP Modals Clase Module Initializing...");
+            console.log("CPP Configuracion Module Initializing...");
+            this.bindEvents();
         },
 
         resetForm: function() {
-            const $modal = $('#cpp-modal-clase');
-            const $form = $modal.find('#cpp-form-clase');
+            const $configTab = $('#cpp-main-tab-configuracion');
+            const $form = $configTab.find('#cpp-form-clase');
 
             if ($form.length) {
                 $form.trigger('reset');
                 $form.find('#clase_id_editar').val('');
                 
-                const $classSwatchesContainer = $modal.find('.cpp-color-swatches-container:not(.cpp-category-color-swatches)');
+                const $classSwatchesContainer = $configTab.find('.cpp-color-swatches-container:not(.cpp-category-color-swatches)');
                 let defaultColor = '#2962FF'; 
                 const firstSwatch = $classSwatchesContainer.find('.cpp-color-swatch:first');
                 if (firstSwatch.length) {
@@ -36,47 +35,42 @@
                 $classSwatchesContainer.find('.cpp-color-swatch').removeClass('selected');
                 if ($defaultClassColorSwatch.length) {
                     $defaultClassColorSwatch.addClass('selected');
-                    $('#color_clase_hidden_modal').val($defaultClassColorSwatch.data('color'));
+                    $('#color_clase_hidden_config').val($defaultClassColorSwatch.data('color'));
                 } else if (firstSwatch.length) {
                     firstSwatch.addClass('selected');
-                    $('#color_clase_hidden_modal').val(firstSwatch.data('color'));
+                    $('#color_clase_hidden_config').val(firstSwatch.data('color'));
                 }
                 
-                $form.find('#base_nota_final_clase_modal').val('100.00');
-                $form.find('#nota_aprobado_clase_modal').val('50.00');
-                $modal.find('#cpp-modal-clase-titulo').text('Crear Nueva Clase');
-                $modal.find('#cpp-submit-clase-btn-modal').html('<span class="dashicons dashicons-saved"></span> Guardar Clase');
-                $modal.find('#cpp-eliminar-clase-modal-btn').hide();
+                $form.find('#base_nota_final_clase_config').val('100.00');
+                $form.find('#nota_aprobado_clase_config').val('50.00');
+                $configTab.find('#cpp-config-clase-titulo').text('Crear Nueva Clase');
+                $configTab.find('#cpp-submit-clase-btn-config').html('<span class="dashicons dashicons-saved"></span> Guardar Clase');
+                $configTab.find('#cpp-eliminar-clase-config-btn').hide();
                 
-                $modal.find('.cpp-tab-nav').show(); 
-                $modal.find('.cpp-tab-link').removeClass('active').show();
-                $modal.find('.cpp-tab-content').removeClass('active').hide();
-                $modal.find('.cpp-tab-link[data-tab="cpp-tab-general"]').addClass('active');
-                $modal.find('#cpp-tab-general').addClass('active').show();
-                
-                $('#cpp-clase-modal-evaluaciones-container').html('<p>Abre una clase existente para gestionar sus evaluaciones.</p>');
-                $('#cpp-clase-modal-ponderaciones-container').html('<p>Abre una clase existente para gestionar sus ponderaciones.</p>');
+                $('#cpp-config-evaluaciones-container').html('<p>Abre una clase existente para gestionar sus evaluaciones.</p>');
+                $('#cpp-config-ponderaciones-container').html('<p>Abre una clase existente para gestionar sus ponderaciones.</p>');
             }
-            this.currentClaseIdForModal = null;
+            this.currentClaseIdForConfig = null;
         },
 
         showParaCrear: function(e) {
             if (e) e.preventDefault();
             
-            const $modal = $('#cpp-modal-clase');
+            // Cambiar a la pestaña de configuración
+            $('.cpp-main-tab-link[data-tab="configuracion"]').trigger('click');
+
             this.resetForm(); 
 
-            $('#cpp-modal-clase-titulo').text('Crear Nueva Clase');
-            $('#cpp-submit-clase-btn-modal').html('<span class="dashicons dashicons-saved"></span> Guardar Clase');
-            $('#cpp-eliminar-clase-modal-btn').hide();
+            $('#cpp-config-clase-titulo').text('Crear Nueva Clase');
+            $('#cpp-submit-clase-btn-config').html('<span class="dashicons dashicons-saved"></span> Guardar Clase');
+            $('#cpp-eliminar-clase-config-btn').hide();
             
-            $modal.find('.cpp-tab-link[data-tab="cpp-tab-evaluaciones"]').hide();
-            $modal.find('.cpp-tab-link[data-tab="cpp-tab-ponderaciones"]').hide();
-
             $('#cpp-opcion-clase-ejemplo-container').show();
             $('#rellenar_clase_ejemplo').prop('checked', false);
             
-            $modal.fadeIn().find('#nombre_clase_modal').focus();
+            // Cambiar a la sub-pestaña de clase
+            this.handleConfigTabClick(null, 'clase');
+            $('#nombre_clase_config').focus();
         },
 
         showParaEditar: function(e, goToPonderaciones = false, claseIdFromParam = null) { 
@@ -93,15 +87,16 @@
             
             if (!claseId) { alert('Error: No se pudo identificar la clase para editar.'); return; }
             
-            const $modal = $('#cpp-modal-clase');
-            const $form = $modal.find('#cpp-form-clase');
+            // Cambiar a la pestaña de configuración
+            $('.cpp-main-tab-link[data-tab="configuracion"]').trigger('click');
+
+            const $configTab = $('#cpp-main-tab-configuracion');
+            const $form = $configTab.find('#cpp-form-clase');
             
             this.resetForm();
-            this.currentClaseIdForModal = claseId; 
+            this.currentClaseIdForConfig = claseId;
 
             $('#cpp-opcion-clase-ejemplo-container').hide();
-
-            $modal.find('.cpp-tab-link').show();
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl, type: 'POST', dataType: 'json',
@@ -109,29 +104,32 @@
                 success: (response) => {
                     if (response.success && response.data.clase) {
                         const clase = response.data.clase;
-                        if (!$modal.length || !$form.length) { return; }
+                        if (!$configTab.length || !$form.length) { return; }
                         
                         $form.find('#clase_id_editar').val(clase.id);
-                        $form.find('#nombre_clase_modal').val(clase.nombre);
+                        $form.find('#nombre_clase_config').val(clase.nombre);
                         
-                        const $classSwatchesContainer = $modal.find('.cpp-color-swatches-container:not(.cpp-category-color-swatches)');
+                        const $classSwatchesContainer = $configTab.find('.cpp-color-swatches-container:not(.cpp-category-color-swatches)');
                         let colorParaSeleccionar = clase.color || $classSwatchesContainer.find('.cpp-color-swatch:first').data('color') || '#2962FF';
                         
-                        $('#color_clase_hidden_modal').val(colorParaSeleccionar);
+                        $('#color_clase_hidden_config').val(colorParaSeleccionar);
                         $classSwatchesContainer.find('.cpp-color-swatch').removeClass('selected');
                         $classSwatchesContainer.find(`.cpp-color-swatch[data-color="${colorParaSeleccionar.toUpperCase()}"]`).addClass('selected');
 
-                        $form.find('#base_nota_final_clase_modal').val(clase.base_nota_final ? parseFloat(clase.base_nota_final).toFixed(2) : '100.00');
-                        $form.find('#nota_aprobado_clase_modal').val(clase.nota_aprobado ? parseFloat(clase.nota_aprobado).toFixed(2) : '50.00');
-                        $modal.find('#cpp-modal-clase-titulo').text(`Editar Clase: ${clase.nombre}`);
-                        $modal.find('#cpp-submit-clase-btn-modal').html('<span class="dashicons dashicons-edit"></span> Actualizar Clase');
+                        $form.find('#base_nota_final_clase_config').val(clase.base_nota_final ? parseFloat(clase.base_nota_final).toFixed(2) : '100.00');
+                        $form.find('#nota_aprobado_clase_config').val(clase.nota_aprobado ? parseFloat(clase.nota_aprobado).toFixed(2) : '50.00');
+                        $configTab.find('#cpp-config-clase-titulo').text(`Editar Clase: ${clase.nombre}`);
+                        $configTab.find('#cpp-submit-clase-btn-config').html('<span class="dashicons dashicons-edit"></span> Actualizar Clase');
                         
-                        $('#cpp-eliminar-clase-modal-btn').show();
+                        $('#cpp-eliminar-clase-config-btn').show();
                         
-                        this.handleTabClick(null, 'cpp-tab-general', $modal);
-                        
-                        $modal.fadeIn();
-                        $form.find('#nombre_clase_modal').focus();
+                        this.handleConfigTabClick(null, 'clase');
+                        $form.find('#nombre_clase_config').focus();
+
+                        // Cargar datos en las otras pestañas
+                        this.refreshEvaluacionesList(claseId);
+                        this.loadPonderacionesTab(claseId);
+
                     } else {
                         alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudieron cargar datos.'));
                         this.resetForm();
@@ -173,8 +171,8 @@
 
             $('#cpp-welcome-box').hide();
 
-            $('#cpp-modal-clase').fadeOut();
-
+            // Cambiar a la pestaña de cuaderno y seleccionar la nueva clase
+            $('.cpp-main-tab-link[data-tab="cuaderno"]').trigger('click');
             $sidebarList.find(`li[data-clase-id="${claseData.id}"] a`).first().trigger('click');
         },
 
@@ -188,7 +186,7 @@
             const nombreClase = $form.find('[name="nombre_clase"]').val().trim();
             const baseNotaFinalClase = $form.find('[name="base_nota_final_clase"]').val().trim();
             const notaAprobadoClase = $form.find('[name="nota_aprobado_clase"]').val().trim();
-            const colorClase = $form.find('#color_clase_hidden_modal').val();
+            const colorClase = $form.find('#color_clase_hidden_config').val();
             const rellenarConEjemplo = $('#rellenar_clase_ejemplo').is(':checked');
 
             if (nombreClase === '') { alert('El nombre de la clase es obligatorio.'); return; }
@@ -245,16 +243,16 @@
             });
         },
         
-        eliminarDesdeModal: function(eventButton) { 
+        eliminarDesdeConfig: function(eventButton) {
             eventButton.preventDefault();
             const $btnEliminar = $(eventButton.currentTarget);
             const claseId = $('#cpp-form-clase #clase_id_editar').val();
-            const claseNombre = $('#cpp-form-clase #nombre_clase_modal').val().trim() || 'esta clase';
+            const claseNombre = $('#cpp-form-clase #nombre_clase_config').val().trim() || 'esta clase';
             if (!claseId) { alert('Error: No se pudo identificar la clase para eliminar.'); return; }
             if (confirm(`¿Estás SEGURO de que quieres eliminar la clase "${claseNombre}"?\n\nATENCIÓN: Esta acción es permanente y no se puede deshacer.`)) {
                 const originalBtnHtml = $btnEliminar.html();
                 $btnEliminar.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span> Eliminando...');
-                $('#cpp-submit-clase-btn-modal').prop('disabled', true); 
+                $('#cpp-submit-clase-btn-config').prop('disabled', true);
                 $.ajax({
                     url: cppFrontendData.ajaxUrl, type: 'POST', dataType: 'json',
                     data: { action: 'cpp_eliminar_clase', nonce: cppFrontendData.nonce, clase_id: claseId },
@@ -264,13 +262,13 @@
                         } else {
                             alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudo eliminar.'));
                             $btnEliminar.prop('disabled', false).html(originalBtnHtml);
-                            $('#cpp-submit-clase-btn-modal').prop('disabled', false);
+                            $('#cpp-submit-clase-btn-config').prop('disabled', false);
                         }
                     },
                     error: function() {
                         alert('Error de conexión al eliminar.');
                         $btnEliminar.prop('disabled', false).html(originalBtnHtml);
-                        $('#cpp-submit-clase-btn-modal').prop('disabled', false);
+                        $('#cpp-submit-clase-btn-config').prop('disabled', false);
                     }
                 });
             }
@@ -311,38 +309,33 @@
             });
         },
 
-        handleTabClick: function(event, targetTabId = null, modalContext = null) { 
+        handleConfigTabClick: function(event, targetTabId = null) {
             if (event) event.preventDefault();
-            const $clickedLink = event ? $(event.currentTarget).closest('.cpp-tab-link') : null;
-            const $modal = modalContext || ($clickedLink ? $clickedLink.closest('.cpp-modal') : $('#cpp-modal-clase'));
-            const tabId = targetTabId || ($clickedLink ? $clickedLink.data('tab') : 'cpp-tab-general');
-            const $targetLink = $modal.find(`.cpp-tab-link[data-tab="${tabId}"]`);
+            const $clickedLink = event ? $(event.currentTarget) : null;
+            const tabId = targetTabId || ($clickedLink ? $clickedLink.data('config-tab') : 'clase');
             
-            $modal.find('.cpp-tab-content').removeClass('active').hide();
-            $modal.find('.cpp-tab-nav .cpp-tab-link').removeClass('active');
-            
-            $modal.find('#' + tabId).addClass('active').show();
-            $targetLink.addClass('active');
-            
-            const claseIdActualEnModal = this.currentClaseIdForModal || $modal.find('#clase_id_editar').val();
+            $('.cpp-config-tab-link').removeClass('active');
+            $('.cpp-config-tab-content').removeClass('active');
 
-            if (tabId === 'cpp-tab-evaluaciones') {
-                if (claseIdActualEnModal && claseIdActualEnModal !== '0') {
-                    this.refreshEvaluacionesList(claseIdActualEnModal);
-                } else {
-                     $('#cpp-clase-modal-evaluaciones-container').html('<p>Guarda la información general de la clase primero para añadir evaluaciones.</p>');
-                }
-            } else if (tabId === 'cpp-tab-ponderaciones') {
-                if (claseIdActualEnModal && claseIdActualEnModal !== '0') {
-                    this.loadPonderacionesTab(claseIdActualEnModal);
-                } else {
-                    $('#cpp-clase-modal-ponderaciones-container').html('<p>Guarda la información general de la clase primero para gestionar las ponderaciones.</p>');
-                }
-            }
+            $(`.cpp-config-tab-link[data-config-tab="${tabId}"]`).addClass('active');
+            $(`#cpp-config-tab-${tabId}`).addClass('active');
+        },
+
+        handleInnerTabClick: function(event) {
+            if (event) event.preventDefault();
+            const $clickedLink = $(event.currentTarget);
+            const $tabsContainer = $clickedLink.closest('.cpp-tabs-container');
+            const tabId = $clickedLink.data('tab');
+
+            $tabsContainer.find('.cpp-tab-link').removeClass('active');
+            $tabsContainer.find('.cpp-tab-content').removeClass('active');
+
+            $clickedLink.addClass('active');
+            $tabsContainer.find('#' + tabId).addClass('active');
         },
 
         loadPonderacionesTab: function(claseId) {
-            const $container = $('#cpp-clase-modal-ponderaciones-container');
+            const $container = $('#cpp-config-ponderaciones-container');
             $container.html('<p class="cpp-cuaderno-cargando">Cargando evaluaciones...</p>');
 
             $.ajax({
@@ -372,7 +365,7 @@
         },
         
         refreshEvaluacionesList: function(claseId) {
-            const $container = $('#cpp-clase-modal-evaluaciones-container');
+            const $container = $('#cpp-config-evaluaciones-container');
             $container.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
             const self = this;
             $.ajax({
@@ -382,7 +375,7 @@
                 data: { action: 'cpp_obtener_evaluaciones', nonce: cppFrontendData.nonce, clase_id: claseId },
                 success: function(response) {
                     if (response.success) {
-                        self.renderEvaluacionesList(response.data.evaluaciones);
+                        self.renderEvaluacionesList(response.data.evaluaciones, claseId);
                     } else {
                         $container.html('<p class="cpp-error-message">Error al cargar las evaluaciones.</p>');
                     }
@@ -393,8 +386,8 @@
             });
         },
         
-        renderEvaluacionesList: function(evaluaciones) {
-            const $container = $('#cpp-clase-modal-evaluaciones-container');
+        renderEvaluacionesList: function(evaluaciones, claseId) {
+            const $container = $('#cpp-config-evaluaciones-container');
             let html = '<h4>Gestionar Evaluaciones</h4>';
             html += '<p><small>Arrastra las evaluaciones para reordenarlas.</small></p>';
             html += '<ul class="cpp-evaluaciones-list">';
@@ -429,7 +422,7 @@
                          </div>`;
             }
             
-            html += `<button type="button" id="cpp-btn-add-evaluacion" class="cpp-btn cpp-btn-primary">Añadir</button>
+            html += `<button type="button" id="cpp-btn-add-evaluacion" class="cpp-btn cpp-btn-primary" data-clase-id="${claseId}">Añadir</button>
                      </div>`;
             
             $container.html(html);
@@ -447,24 +440,16 @@
         },
 
         bindEvents: function() {
-            console.log("Binding Modals Clase events...");
-            const $modalClase = $('#cpp-modal-clase'); 
+            const $mainContent = $('#cpp-cuaderno-main-content');
 
-            // Manejo del Enter en el formulario de la clase
-            $modalClase.on('keydown', '#cpp-form-clase', (e) => {
-                if (e.key === 'Enter' && $(e.target).is('#nombre_clase_modal')) {
-                    if (typeof cpp.tutorial !== 'undefined' && cpp.tutorial.isActive && cpp.tutorial.currentStep === 1) {
-                        e.preventDefault();
-                    }
-                }
-            });
+            $mainContent.on('click', '.cpp-config-tab-link', (e) => { this.handleConfigTabClick(e); });
+            $mainContent.on('click', '#cpp-config-tab-evaluaciones .cpp-tab-link', (e) => { this.handleInnerTabClick(e); });
 
-            $modalClase.on('submit', '#cpp-form-clase', (e) => { this.guardar(e); });
-            $modalClase.on('click', '#cpp-eliminar-clase-modal-btn', (e) => { this.eliminarDesdeModal(e); });
-            $modalClase.on('click', '.cpp-tab-link', (e) => { this.handleTabClick(e, null, $modalClase); });
+            $mainContent.on('submit', '#cpp-form-clase', (e) => { this.guardar(e); });
+            $mainContent.on('click', '#cpp-eliminar-clase-config-btn', (e) => { this.eliminarDesdeConfig(e); });
 
-            $modalClase.on('change', '#cpp-ponderaciones-eval-selector', function() {
-                const evaluacionId = $(this).val();
+            $mainContent.on('change', '#cpp-ponderaciones-eval-selector', (e) => {
+                const evaluacionId = $(e.currentTarget).val();
                 const $settingsContainer = $('#cpp-ponderaciones-settings-content');
                 if (evaluacionId) {
                     $settingsContainer.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
@@ -478,12 +463,13 @@
 
             $('body').on('click', '#cpp-btn-crear-clase-ejemplo', (e) => { this.crearClaseEjemplo(e, 'Clase de Ejemplo', '#cd18be'); });
 
-            const evaluacionContainerSelector = '#cpp-clase-modal-evaluaciones-container';
+            const evaluacionContainerSelector = '#cpp-config-evaluaciones-container';
 
-            $modalClase.on('click', `${evaluacionContainerSelector} #cpp-btn-add-evaluacion`, () => {
+            $mainContent.on('click', `${evaluacionContainerSelector} #cpp-btn-add-evaluacion`, (e) => {
+                const $button = $(e.currentTarget);
                 const $input = $('#cpp-nombre-nueva-evaluacion');
                 const nombre = $input.val().trim();
-                const claseId = this.currentClaseIdForModal;
+                const claseId = $button.data('clase-id') || this.currentClaseIdForConfig;
                 const sourceEvalId = $('#cpp-copy-from-eval-select').val() || '0';
 
                 if (!nombre) { alert('El nombre de la evaluación no puede estar vacío.'); $input.focus(); return; }
@@ -501,6 +487,7 @@
                     success: (response) => {
                         if(response.success) {
                             this.refreshEvaluacionesList(claseId);
+                            this.loadPonderacionesTab(claseId); // Recargar también las ponderaciones
                         } else {
                             alert('Error: ' + (response.data.message || 'No se pudo crear la evaluación.'));
                         }
@@ -508,12 +495,12 @@
                 });
             });
 
-            $modalClase.on('click', `${evaluacionContainerSelector} .cpp-btn-eliminar-evaluacion`, (e) => {
+            $mainContent.on('click', `${evaluacionContainerSelector} .cpp-btn-eliminar-evaluacion`, (e) => {
                 e.preventDefault();
                 const $li = $(e.currentTarget).closest('li');
                 const evaluacionId = $li.data('evaluacion-id');
                 const evaluacionNombre = $li.find('.cpp-evaluacion-nombre').text();
-                const claseId = this.currentClaseIdForModal;
+                const claseId = this.currentClaseIdForConfig;
                 if (confirm(`¿Estás SEGURO de que quieres eliminar la evaluación "${evaluacionNombre}"?\n\n¡Se borrarán TODAS las actividades y notas asociadas a ella!`)) {
                     $.ajax({
                         url: cppFrontendData.ajaxUrl, type: 'POST', dataType: 'json',
@@ -521,6 +508,7 @@
                         success: (response) => {
                             if(response.success) {
                                 this.refreshEvaluacionesList(claseId);
+                                this.loadPonderacionesTab(claseId);
                             } else {
                                 alert('Error: ' + (response.data.message || 'No se pudo eliminar la evaluación.'));
                             }
@@ -529,7 +517,7 @@
                 }
             });
             
-            $modalClase.on('click', `${evaluacionContainerSelector} .cpp-btn-editar-evaluacion`, (e) => {
+            $mainContent.on('click', `${evaluacionContainerSelector} .cpp-btn-editar-evaluacion`, (e) => {
                 e.preventDefault();
                 const $li = $(e.currentTarget).closest('li');
                 $li.find('.cpp-evaluacion-nombre, .cpp-evaluacion-actions').hide();
@@ -543,19 +531,19 @@
                 $li.find('input[type="text"]').focus().select();
             });
 
-            $modalClase.on('click', `${evaluacionContainerSelector} .cpp-btn-cancel-edit-evaluacion`, (e) => {
+            $mainContent.on('click', `${evaluacionContainerSelector} .cpp-btn-cancel-edit-evaluacion`, (e) => {
                 e.preventDefault();
                 const $li = $(e.currentTarget).closest('li');
                 $li.find('.cpp-evaluacion-edit-form').remove();
                 $li.find('.cpp-evaluacion-nombre, .cpp-evaluacion-actions').show();
             });
 
-            $modalClase.on('click', `${evaluacionContainerSelector} .cpp-btn-save-evaluacion`, (e) => {
+            $mainContent.on('click', `${evaluacionContainerSelector} .cpp-btn-save-evaluacion`, (e) => {
                 e.preventDefault();
                 const $li = $(e.currentTarget).closest('li');
                 const evaluacionId = $li.data('evaluacion-id');
                 const nuevoNombre = $li.find('input[type="text"]').val().trim();
-                const claseId = this.currentClaseIdForModal;
+                const claseId = this.currentClaseIdForConfig;
                 if (!nuevoNombre) { alert('El nombre no puede estar vacío.'); return; }
                 
                 $.ajax({
@@ -564,6 +552,7 @@
                     success: (response) => {
                         if(response.success) {
                             this.refreshEvaluacionesList(claseId);
+                            this.loadPonderacionesTab(claseId);
                         } else {
                             alert('Error: ' + (response.data.message || 'No se pudo actualizar.'));
                         }

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -381,19 +381,6 @@
             $(`#cpp-config-tab-${tabId}`).addClass('active');
         },
 
-        handleInnerTabClick: function(event) {
-            if (event) event.preventDefault();
-            const $clickedLink = $(event.currentTarget);
-            const $tabsContainer = $clickedLink.closest('.cpp-tabs-container');
-            const tabId = $clickedLink.data('tab');
-
-            $tabsContainer.find('.cpp-tab-link').removeClass('active');
-            $tabsContainer.find('.cpp-tab-content').removeClass('active');
-
-            $clickedLink.addClass('active');
-            $tabsContainer.find('#' + tabId).addClass('active');
-        },
-
         loadPonderacionesTab: function(claseId) {
             const $container = $('#cpp-config-ponderaciones-container');
             $container.html('<p class="cpp-cuaderno-cargando">Cargando evaluaciones...</p>');

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -187,8 +187,7 @@
                         $form.find('#nombre_clase_config').focus();
 
                         // Cargar datos en las otras pestañas
-                        this.refreshEvaluacionesList(claseId);
-                        this.loadPonderacionesTab(claseId);
+                        this.cargarContenidoEvaluaciones(claseId);
 
                     } else {
                         alert('Error: ' + (response.data && response.data.message ? response.data.message : 'No se pudieron cargar datos.'));
@@ -381,9 +380,13 @@
             $(`#cpp-config-tab-${tabId}`).addClass('active');
         },
 
-        loadPonderacionesTab: function(claseId) {
-            const $container = $('#cpp-config-ponderaciones-container');
-            $container.html('<p class="cpp-cuaderno-cargando">Cargando evaluaciones...</p>');
+        cargarContenidoEvaluaciones: function(claseId) {
+            const self = this;
+            const $evaluacionesContainer = $('#cpp-config-evaluaciones-container');
+            const $ponderacionesContainer = $('#cpp-config-ponderaciones-container');
+
+            $evaluacionesContainer.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
+            $ponderacionesContainer.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -391,44 +394,34 @@
                 dataType: 'json',
                 data: { action: 'cpp_obtener_evaluaciones', nonce: cppFrontendData.nonce, clase_id: claseId },
                 success: function(response) {
-                    if (response.success && response.data.evaluaciones && response.data.evaluaciones.length > 0) {
-                        let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
-                        contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
-                        contentHtml += '<option value="">-- Selecciona --</option>';
-                        response.data.evaluaciones.forEach(function(evaluacion) {
-                            contentHtml += `<option value="${evaluacion.id}">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</option>`;
-                        });
-                        contentHtml += '</select></div><hr>';
-                        contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
-                        $container.html(contentHtml);
-                    } else {
-                        $container.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la pestaña "Evaluaciones".</p>');
-                    }
-                },
-                error: function() {
-                    $container.html('<p class="cpp-error-message">Error al cargar las evaluaciones.</p>');
-                }
-            });
-        },
-        
-        refreshEvaluacionesList: function(claseId) {
-            const $container = $('#cpp-config-evaluaciones-container');
-            $container.html('<p class="cpp-cuaderno-cargando">Cargando...</p>');
-            const self = this;
-            $.ajax({
-                url: cppFrontendData.ajaxUrl,
-                type: 'POST',
-                dataType: 'json',
-                data: { action: 'cpp_obtener_evaluaciones', nonce: cppFrontendData.nonce, clase_id: claseId },
-                success: function(response) {
                     if (response.success) {
+                        // Renderizar lista de evaluaciones
                         self.renderEvaluacionesList(response.data.evaluaciones, claseId);
+
+                        // Renderizar sección de ponderaciones
+                        if (response.data.evaluaciones && response.data.evaluaciones.length > 0) {
+                            let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
+                            contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
+                            contentHtml += '<option value="">-- Selecciona --</option>';
+                            response.data.evaluaciones.forEach(function(evaluacion) {
+                                contentHtml += `<option value="${evaluacion.id}">${$('<div>').text(evaluacion.nombre_evaluacion).html()}</option>`;
+                            });
+                            contentHtml += '</select></div><hr>';
+                            contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
+                            $ponderacionesContainer.html(contentHtml);
+                        } else {
+                            $ponderacionesContainer.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la sección de arriba.</p>');
+                        }
                     } else {
-                        $container.html('<p class="cpp-error-message">Error al cargar las evaluaciones.</p>');
+                        const errorMsg = '<p class="cpp-error-message">Error al cargar las evaluaciones.</p>';
+                        $evaluacionesContainer.html(errorMsg);
+                        $ponderacionesContainer.html(errorMsg);
                     }
                 },
                 error: function() {
-                    $container.html('<p class="cpp-error-message">Error de conexión.</p>');
+                    const errorMsg = '<p class="cpp-error-message">Error de conexión.</p>';
+                    $evaluacionesContainer.html(errorMsg);
+                    $ponderacionesContainer.html(errorMsg);
                 }
             });
         },

--- a/assets/js/cpp-core.js
+++ b/assets/js/cpp-core.js
@@ -26,7 +26,7 @@ const cpp = {
         console.log("CPP Core: cppFrontendData disponible:", cppFrontendData);
 
         const modulesToInitialize = [
-            'utils', 'sidebar', 'gradebook', 'programador',
+            'utils', 'sidebar', 'gradebook',
             'modals.general', 'config', 'modals.alumnos',
             'modals.actividades', 'modals.excel', 'modals.asistencia',
             'modals.fichaAlumno', 'modals.evaluacion'
@@ -63,6 +63,7 @@ const cpp = {
     },
 
     bindCoreEvents: function() {
+        const $ = jQuery;
         const $document = $(document);
 
         $document.on('click', '.cpp-main-tab-link', function(e) {

--- a/assets/js/cpp-core.js
+++ b/assets/js/cpp-core.js
@@ -59,6 +59,13 @@ const cpp = {
         this.bindCoreEvents();
         this.initializeCuadernoView();
 
+        // El módulo programador se inicializa de forma independiente si existe
+        if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.init === 'function') {
+            console.log(`CPP Core: Initializing CppProgramadorApp...`);
+            const initialClaseId = this.getInitialClaseId();
+            CppProgramadorApp.init(initialClaseId);
+        }
+
         console.log("CPP Core: init() completado.");
     },
 
@@ -95,6 +102,24 @@ const cpp = {
                 cpp.config.showParaCrear(e);
             }
         });
+    },
+
+    getInitialClaseId: function() {
+        const $clasesSidebarItems = jQuery('.cpp-sidebar-clases-list .cpp-sidebar-clase-item');
+        let claseIdToLoad = null;
+
+        if (typeof localStorage !== 'undefined' && cppFrontendData && cppFrontendData.userId && cppFrontendData.userId !== '0') {
+            const lastOpenedClaseId = localStorage.getItem('cpp_last_opened_clase_id_user_' + cppFrontendData.userId);
+            if (lastOpenedClaseId && $clasesSidebarItems.filter(`[data-clase-id="${lastOpenedClaseId}"]`).length > 0) {
+                claseIdToLoad = lastOpenedClaseId;
+            }
+        }
+
+        if (!claseIdToLoad && $clasesSidebarItems.length > 0) {
+            claseIdToLoad = $clasesSidebarItems.first().data('clase-id');
+        }
+
+        return claseIdToLoad;
     },
 
     initializeCuadernoView: function() {

--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -27,6 +27,7 @@
                 const savedDirection = localStorage.getItem(this.localStorageKey_enterDirection + cppFrontendData.userId);
                 if (savedDirection === 'right' || savedDirection === 'down') { this.enterKeyDirection = savedDirection; }
             }
+            this.bindEvents();
         },
 
         updateSortButton: function(sortOrder) {

--- a/assets/js/cpp-modales-evaluacion.js
+++ b/assets/js/cpp-modales-evaluacion.js
@@ -179,7 +179,7 @@
             const $document = $(document);
             const self = this;
 
-            const containerSelector = '#cpp-clase-modal-ponderaciones-container';
+            const containerSelector = '#cpp-config-ponderaciones-container';
             
             $document.on('change', `${containerSelector} input[name="metodo_calculo_evaluacion"]`, function() {
                 const nuevoMetodo = $(this).val();

--- a/assets/js/cpp-modales-evaluacion.js
+++ b/assets/js/cpp-modales-evaluacion.js
@@ -15,6 +15,7 @@
 
         init: function() {
             console.log("CPP Modals Evaluacion Module Initializing...");
+            this.bindEvents();
         },
 
         refreshCategoriasList: function(evaluacionId, containerSelector) {

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -56,9 +56,13 @@ const CppProgramadorApp = {
         });
 
         $document.on('click', '#cpp-programador-app #cpp-horario-config-btn', function() {
-            // Cambiar a la pestaña principal de Configuración
-            $('.cpp-main-tab-link[data-tab="configuracion"]').trigger('click');
-            // Activar la sub-pestaña de Calendario
+            // Manually switch main tab
+            $('.cpp-main-tab-link').removeClass('active');
+            $('.cpp-main-tab-link[data-tab="configuracion"]').addClass('active');
+            $('.cpp-main-tab-content').removeClass('active');
+            $('#cpp-main-tab-configuracion').addClass('active');
+
+            // Manually switch sub-tab
             if (cpp.config && typeof cpp.config.handleConfigTabClick === 'function') {
                 cpp.config.handleConfigTabClick(null, 'calendario');
             }

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -56,7 +56,12 @@ const CppProgramadorApp = {
         });
 
         $document.on('click', '#cpp-programador-app #cpp-horario-config-btn', function() {
-            self.openConfigModal();
+            // Cambiar a la pestaña principal de Configuración
+            $('.cpp-main-tab-link[data-tab="configuracion"]').trigger('click');
+            // Activar la sub-pestaña de Calendario
+            if (cpp.config && typeof cpp.config.handleConfigTabClick === 'function') {
+                cpp.config.handleConfigTabClick(null, 'calendario');
+            }
         });
 
         // Listeners for config modal

--- a/assets/js/cpp-sidebar.js
+++ b/assets/js/cpp-sidebar.js
@@ -171,10 +171,10 @@
                 }
             });
             $document.on('click', '#cpp-btn-nueva-clase-sidebar', function(e){ 
-                if (cpp.config && typeof cpp.config.showParaCrear === 'function') {
-                    cpp.config.showParaCrear(e);
+                if (cpp.config && typeof cpp.config.showModalParaCrear === 'function') {
+                    cpp.config.showModalParaCrear(e);
                 } else {
-                    console.error("Función cpp.config.showParaCrear no encontrada.");
+                    console.error("Función cpp.config.showModalParaCrear no encontrada.");
                 }
             });
         }

--- a/assets/js/cpp-sidebar.js
+++ b/assets/js/cpp-sidebar.js
@@ -15,7 +15,7 @@
         init: function() {
             console.log("CPP Sidebar Module Initializing...");
             this.initSortableClases();
-            // bindEvents se llamará desde cpp.core.js
+            this.bindEvents();
         },
 
         initSortableClases: function() {

--- a/assets/js/cpp-sidebar.js
+++ b/assets/js/cpp-sidebar.js
@@ -164,17 +164,17 @@
             });
 
             $document.on('click', '.cpp-sidebar-clase-settings-btn', function(e){ 
-                if (cpp.modals && cpp.modals.clase && typeof cpp.modals.clase.showParaEditar === 'function') {
-                    cpp.modals.clase.showParaEditar(e); 
+                if (cpp.config && typeof cpp.config.showParaEditar === 'function') {
+                    cpp.config.showParaEditar(e);
                 } else {
-                    console.error("Función cpp.modals.clase.showParaEditar no encontrada.");
+                    console.error("Función cpp.config.showParaEditar no encontrada.");
                 }
             });
             $document.on('click', '#cpp-btn-nueva-clase-sidebar', function(e){ 
-                if (cpp.modals && cpp.modals.clase && typeof cpp.modals.clase.showParaCrear === 'function') {
-                    cpp.modals.clase.showParaCrear(e);
+                if (cpp.config && typeof cpp.config.showParaCrear === 'function') {
+                    cpp.config.showParaCrear(e);
                 } else {
-                    console.error("Función cpp.modals.clase.showParaCrear no encontrada.");
+                    console.error("Función cpp.config.showParaCrear no encontrada.");
                 }
             });
         }

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -63,9 +63,9 @@ function cpp_cargar_assets() {
     wp_enqueue_script('cpp-programador-js', CPP_PLUGIN_URL . 'assets/js/cpp-programador.js', ['cpp-core-js', 'jquery-ui-droppable', 'jquery-ui-draggable'], $plugin_version, true);
     wp_enqueue_script('cpp-cuaderno-js', CPP_PLUGIN_URL . 'assets/js/cpp-cuaderno.js', ['cpp-core-js', 'cpp-programador-js'], $plugin_version, true);
 
-    // Módulos de modales
+    // Módulos de modales y configuración
     wp_enqueue_script('cpp-modales-general-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-general.js', ['cpp-core-js'], $plugin_version, true);
-    wp_enqueue_script('cpp-modales-clase-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-clase.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
+    wp_enqueue_script('cpp-configuracion-js', CPP_PLUGIN_URL . 'assets/js/cpp-configuracion.js', ['cpp-core-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-alumnos-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-alumnos.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-actividad-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-actividad.js', ['cpp-core-js', 'cpp-modales-general-js', 'cpp-cuaderno-js'], $plugin_version, true);
     wp_enqueue_script('cpp-modales-excel-js', CPP_PLUGIN_URL . 'assets/js/cpp-modales-excel.js', ['cpp-core-js', 'cpp-modales-general-js'], $plugin_version, true);

--- a/includes/db-queries/queries-clases.php
+++ b/includes/db-queries/queries-clases.php
@@ -8,7 +8,7 @@ defined('ABSPATH') or die('Acceso no permitido');
 function cpp_obtener_clase_completa_por_id($clase_id, $user_id) {
     global $wpdb;
     $tabla_clases = $wpdb->prefix . 'cpp_clases';
-    return $wpdb->get_row(
+    $clase_data = $wpdb->get_row(
         $wpdb->prepare(
             "SELECT id, user_id, nombre, color, base_nota_final, nota_aprobado, orden, fecha_creacion FROM $tabla_clases WHERE id = %d AND user_id = %d",
             $clase_id,
@@ -16,6 +16,13 @@ function cpp_obtener_clase_completa_por_id($clase_id, $user_id) {
         ),
         ARRAY_A 
     );
+
+    if ($clase_data) {
+        // Incluir las evaluaciones directamente en los datos de la clase
+        $clase_data['evaluaciones'] = cpp_obtener_evaluaciones_por_clase($clase_id, $user_id);
+    }
+
+    return $clase_data;
 }
 
 function cpp_actualizar_clase_completa($clase_id, $user_id, $datos) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -79,10 +79,10 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                 <div class="cpp-top-bar-center">
                     <div class="cpp-main-tabs-nav">
                         <button class="cpp-main-tab-link active" data-tab="cuaderno">Cuaderno</button>
-                        <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
                         <button class="cpp-main-tab-link" data-tab="programacion">Programación</button>
                         <button class="cpp-main-tab-link" data-tab="semana">Semana</button>
                         <button class="cpp-main-tab-link" data-tab="horario">Horario</button>
+                        <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
                     </div>
                 </div>
                 <div class="cpp-top-bar-right">

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -190,22 +190,14 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                                     </form>
                                 </div>
                                 <div id="cpp-config-tab-evaluaciones" class="cpp-config-tab-content">
-                                    <h2>Evaluaciones y Ponderaciones</h2>
-                                    <div class="cpp-tabs-container">
-                                        <div class="cpp-tab-nav">
-                                            <button type="button" class="cpp-tab-link active" data-tab="cpp-tab-evaluaciones-config">Evaluaciones de la clase</button>
-                                            <button type="button" class="cpp-tab-link" data-tab="cpp-tab-ponderaciones-config">Tipo de ponderación y categorías</button>
-                                        </div>
-                                        <div id="cpp-tab-evaluaciones-config" class="cpp-tab-content active">
-                                            <div id="cpp-config-evaluaciones-container">
-                                                <p>Cargando evaluaciones...</p>
-                                            </div>
-                                        </div>
-                                        <div id="cpp-tab-ponderaciones-config" class="cpp-tab-content">
-                                            <div id="cpp-config-ponderaciones-container">
-                                                <p>Selecciona una evaluación para ver sus ponderaciones.</p>
-                                            </div>
-                                        </div>
+                                    <h2>Evaluaciones de la Clase</h2>
+                                    <div id="cpp-config-evaluaciones-container">
+                                        <p>Cargando evaluaciones...</p>
+                                    </div>
+                                    <hr style="margin: 40px 0;">
+                                    <h2>Ponderaciones y Categorías</h2>
+                                    <div id="cpp-config-ponderaciones-container">
+                                        <p>Selecciona una evaluación para ver sus ponderaciones.</p>
                                     </div>
                                 </div>
                                 <div id="cpp-config-tab-calendario" class="cpp-config-tab-content">

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -270,7 +270,53 @@ function cpp_shortcode_cuaderno_notas_classroom() {
 
         <?php
         // --- INICIO DE LA SECCIÓN DE MODALES ---
-        
+
+        if (empty(did_action('cpp_modal_crear_clase_outputted'))) {
+            ?>
+            <div class="cpp-modal" id="cpp-modal-crear-clase">
+                <div class="cpp-modal-content">
+                    <span class="cpp-modal-close">&times;</span>
+                    <h2 id="cpp-modal-crear-clase-titulo">Crear Nueva Clase</h2>
+                    <form id="cpp-form-crear-clase" novalidate>
+                        <div class="cpp-form-group">
+                            <label for="nombre_clase_modal_crear">Nombre de la clase (máx. 16 caracteres):</label>
+                            <input type="text" id="nombre_clase_modal_crear" name="nombre_clase" required maxlength="16">
+                        </div>
+                        <div class="cpp-form-group">
+                            <label style="font-weight:normal; display:flex; align-items: center; gap: 8px;">
+                                <input type="checkbox" id="rellenar_clase_ejemplo_modal_crear" name="rellenar_clase_ejemplo">
+                                Rellenar la clase con datos de ejemplo
+                            </label>
+                        </div>
+                        <div class="cpp-form-group">
+                            <label>Color de la clase:</label>
+                            <div class="cpp-color-swatches-container">
+                                <?php foreach ($milan_vivid_colors as $hex => $name): ?>
+                                    <span class="cpp-color-swatch <?php echo (strtoupper($hex) === strtoupper($default_class_color_hex)) ? 'selected' : ''; ?>" data-color="<?php echo esc_attr($hex); ?>" style="background-color: <?php echo esc_attr($hex); ?>;" title="<?php echo esc_attr($name); ?>"></span>
+                                <?php endforeach; ?>
+                            </div>
+                            <input type="hidden" id="color_clase_hidden_modal_crear" name="color_clase" value="<?php echo esc_attr($default_class_color_hex); ?>">
+                        </div>
+                        <div class="cpp-form-group">
+                            <label for="base_nota_final_clase_modal_crear">Base Nota Final (ej: 10, 100):</label>
+                            <input type="number" id="base_nota_final_clase_modal_crear" name="base_nota_final_clase" value="100" step="0.01" min="1" required>
+                            <small>La nota final de los alumnos se calculará sobre esta base.</small>
+                        </div>
+                        <div class="cpp-form-group">
+                            <label for="nota_aprobado_clase_modal_crear">Nota mínima para aprobar (ej: 5, 50):</label>
+                            <input type="number" id="nota_aprobado_clase_modal_crear" name="nota_aprobado_clase" value="50" step="0.01" min="0" required>
+                            <small>Los alumnos con una nota final inferior a esta se considerarán suspensos.</small>
+                        </div>
+                        <div class="cpp-modal-actions">
+                            <button type="submit" class="cpp-btn cpp-btn-primary"><span class="dashicons dashicons-saved"></span> Guardar Clase</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <?php
+            do_action('cpp_modal_crear_clase_outputted');
+        }
+
         if (empty(did_action('cpp_modal_alumnos_outputted'))) {
             ?>
             <div class="cpp-modal" id="cpp-modal-alumnos"><div class="cpp-modal-content"><span class="cpp-modal-close">&times;</span><h2 id="cpp-modal-alumnos-title">Gestión de Alumnos</h2><div id="cpp-alumnos-container"></div></div></div>

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -79,9 +79,8 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                 <div class="cpp-top-bar-center">
                     <div class="cpp-main-tabs-nav">
                         <button class="cpp-main-tab-link active" data-tab="cuaderno">Cuaderno</button>
+                        <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
                         <button class="cpp-main-tab-link" data-tab="programacion">Programación</button>
-                        <button class="cpp-main-tab-link" data-tab="semana">Semana</button>
-                        <button class="cpp-main-tab-link" data-tab="horario">Horario</button>
                     </div>
                 </div>
                 <div class="cpp-top-bar-right">
@@ -127,8 +126,124 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         </div>
                     </div>
                     <div id="cpp-main-tab-programacion" class="cpp-main-tab-content"></div>
-                    <div id="cpp-main-tab-semana" class="cpp-main-tab-content"></div>
-                    <div id="cpp-main-tab-horario" class="cpp-main-tab-content"></div>
+                    <div id="cpp-main-tab-configuracion" class="cpp-main-tab-content">
+                        <div class="cpp-config-container">
+                            <div class="cpp-config-sidebar">
+                                <a href="#" class="cpp-config-tab-link active" data-config-tab="clase">
+                                    <span class="dashicons dashicons-admin-settings"></span>
+                                    <span>Clase</span>
+                                </a>
+                                <a href="#" class="cpp-config-tab-link" data-config-tab="evaluaciones">
+                                    <span class="dashicons dashicons-chart-bar"></span>
+                                    <span>Evaluaciones</span>
+                                </a>
+                                <a href="#" class="cpp-config-tab-link" data-config-tab="calendario">
+                                    <span class="dashicons dashicons-calendar-alt"></span>
+                                    <span>Calendario</span>
+                                </a>
+                            </div>
+                            <div class="cpp-config-content-area">
+                                <div id="cpp-config-tab-clase" class="cpp-config-tab-content active">
+                                    <form id="cpp-form-clase" novalidate>
+                                        <input type="hidden" id="clase_id_editar" name="clase_id_editar" value="">
+                                        <h2 id="cpp-config-clase-titulo">Configuración de la Clase</h2>
+
+                                        <h3>Información General</h3>
+                                        <div class="cpp-form-group">
+                                            <label for="nombre_clase_config">Nombre de la clase (máx. 16 caracteres):</label>
+                                            <input type="text" id="nombre_clase_config" name="nombre_clase" required maxlength="16">
+                                        </div>
+                                        <div class="cpp-form-group" id="cpp-opcion-clase-ejemplo-container" style="display: none;">
+                                            <label style="font-weight:normal; display:flex; align-items: center; gap: 8px;">
+                                                <input type="checkbox" id="rellenar_clase_ejemplo" name="rellenar_clase_ejemplo">
+                                                Rellenar la clase con datos de ejemplo
+                                            </label>
+                                        </div>
+                                        <div class="cpp-form-group">
+                                            <label>Color de la clase:</label>
+                                            <div class="cpp-color-swatches-container">
+                                                <?php foreach ($milan_vivid_colors as $hex => $name): ?>
+                                                    <span class="cpp-color-swatch <?php echo (strtoupper($hex) === strtoupper($default_class_color_hex)) ? 'selected' : ''; ?>" data-color="<?php echo esc_attr($hex); ?>" style="background-color: <?php echo esc_attr($hex); ?>;" title="<?php echo esc_attr($name); ?>"></span>
+                                                <?php endforeach; ?>
+                                            </div>
+                                            <input type="hidden" id="color_clase_hidden_config" name="color_clase" value="<?php echo esc_attr($default_class_color_hex); ?>">
+                                        </div>
+                                        <div class="cpp-form-group">
+                                            <label for="base_nota_final_clase_config">Base Nota Final (ej: 10, 100):</label>
+                                            <input type="number" id="base_nota_final_clase_config" name="base_nota_final_clase" value="100" step="0.01" min="1" required>
+                                            <small>La nota final de los alumnos se calculará sobre esta base.</small>
+                                        </div>
+                                        <div class="cpp-form-group">
+                                            <label for="nota_aprobado_clase_config">Nota mínima para aprobar (ej: 5, 50):</label>
+                                            <input type="number" id="nota_aprobado_clase_config" name="nota_aprobado_clase" value="50" step="0.01" min="0" required>
+                                            <small>Los alumnos con una nota final inferior a esta se considerarán suspensos.</small>
+                                        </div>
+
+                                        <div class="cpp-config-actions">
+                                            <button type="submit" class="cpp-btn cpp-btn-primary cpp-config-submit-btn" id="cpp-submit-clase-btn-config"><span class="dashicons dashicons-saved"></span> Guardar Clase</button>
+                                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-clase-config-btn" style="display: none; margin-left: auto;"><span class="dashicons dashicons-trash"></span> Eliminar Clase</button>
+                                        </div>
+                                    </form>
+                                </div>
+                                <div id="cpp-config-tab-evaluaciones" class="cpp-config-tab-content">
+                                    <h2>Evaluaciones y Ponderaciones</h2>
+                                    <div class="cpp-tabs-container">
+                                        <div class="cpp-tab-nav">
+                                            <button type="button" class="cpp-tab-link active" data-tab="cpp-tab-evaluaciones-config">Evaluaciones de la clase</button>
+                                            <button type="button" class="cpp-tab-link" data-tab="cpp-tab-ponderaciones-config">Tipo de ponderación y categorías</button>
+                                        </div>
+                                        <div id="cpp-tab-evaluaciones-config" class="cpp-tab-content active">
+                                            <div id="cpp-config-evaluaciones-container">
+                                                <p>Cargando evaluaciones...</p>
+                                            </div>
+                                        </div>
+                                        <div id="cpp-tab-ponderaciones-config" class="cpp-tab-content">
+                                            <div id="cpp-config-ponderaciones-container">
+                                                <p>Selecciona una evaluación para ver sus ponderaciones.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="cpp-config-tab-calendario" class="cpp-config-tab-content">
+                                    <h2>Configuración del Calendario</h2>
+                                    <form id="cpp-config-form">
+                                        <div class="cpp-form-section">
+                                            <h3>Días lectivos</h3>
+                                            <div id="cpp-working-days" class="cpp-form-group">
+                                                <label><input type="checkbox" name="working_days" value="mon"> Lunes</label>
+                                                <label><input type="checkbox" name="working_days" value="tue"> Martes</label>
+                                                <label><input type="checkbox" name="working_days" value="wed"> Miércoles</label>
+                                                <label><input type="checkbox" name="working_days" value="thu"> Jueves</label>
+                                                <label><input type="checkbox" name="working_days" value="fri"> Viernes</label>
+                                                <label><input type="checkbox" name="working_days" value="sat"> Sábado</label>
+                                                <label><input type="checkbox" name="working_days" value="sun"> Domingo</label>
+                                            </div>
+                                        </div>
+                                        <div class="cpp-form-section">
+                                            <h3>Días festivos</h3>
+                                            <div id="cpp-holidays-list" class="cpp-dynamic-list"></div>
+                                            <div class="cpp-form-group">
+                                                <input type="date" id="cpp-new-holiday-date">
+                                                <button type="button" id="cpp-add-holiday-btn" class="cpp-btn cpp-btn-secondary">Añadir festivo</button>
+                                            </div>
+                                        </div>
+                                        <div class="cpp-form-section">
+                                            <h3>Periodos de vacaciones</h3>
+                                            <div id="cpp-vacations-list" class="cpp-dynamic-list"></div>
+                                            <div class="cpp-form-group">
+                                                <label>Inicio: <input type="date" id="cpp-new-vacation-start"></label>
+                                                <label>Fin: <input type="date" id="cpp-new-vacation-end"></label>
+                                                <button type="button" id="cpp-add-vacation-btn" class="cpp-btn cpp-btn-secondary">Añadir vacaciones</button>
+                                            </div>
+                                        </div>
+                                        <div class="cpp-config-actions">
+                                            <button type="submit" class="cpp-btn cpp-btn-primary">Guardar Configuración</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div id="cpp-sesion-modal" class="cpp-modal" style="display:none;">
                     <div class="cpp-modal-content">
@@ -144,46 +259,6 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         </form>
                     </div>
                 </div>
-                <div id="cpp-config-modal" class="cpp-modal" style="display:none;">
-                    <div class="cpp-modal-content">
-                        <span class="cpp-modal-close">&times;</span>
-                        <h2>Configuración del Calendario</h2>
-                        <form id="cpp-config-form">
-                            <div class="cpp-form-section">
-                                <h3>Días lectivos</h3>
-                                <div id="cpp-working-days" class="cpp-form-group">
-                                    <label><input type="checkbox" name="working_days" value="mon"> Lunes</label>
-                                    <label><input type="checkbox" name="working_days" value="tue"> Martes</label>
-                                    <label><input type="checkbox" name="working_days" value="wed"> Miércoles</label>
-                                    <label><input type="checkbox" name="working_days" value="thu"> Jueves</label>
-                                    <label><input type="checkbox" name="working_days" value="fri"> Viernes</label>
-                                    <label><input type="checkbox" name="working_days" value="sat"> Sábado</label>
-                                    <label><input type="checkbox" name="working_days" value="sun"> Domingo</label>
-                                </div>
-                            </div>
-                            <div class="cpp-form-section">
-                                <h3>Días festivos</h3>
-                                <div id="cpp-holidays-list" class="cpp-dynamic-list"></div>
-                                <div class="cpp-form-group">
-                                    <input type="date" id="cpp-new-holiday-date">
-                                    <button type="button" id="cpp-add-holiday-btn" class="cpp-btn cpp-btn-secondary">Añadir festivo</button>
-                                </div>
-                            </div>
-                            <div class="cpp-form-section">
-                                <h3>Periodos de vacaciones</h3>
-                                <div id="cpp-vacations-list" class="cpp-dynamic-list"></div>
-                                <div class="cpp-form-group">
-                                    <label>Inicio: <input type="date" id="cpp-new-vacation-start"></label>
-                                    <label>Fin: <input type="date" id="cpp-new-vacation-end"></label>
-                                    <button type="button" id="cpp-add-vacation-btn" class="cpp-btn cpp-btn-secondary">Añadir vacaciones</button>
-                                </div>
-                            </div>
-                            <div class="cpp-modal-actions">
-                                <button type="submit" class="cpp-btn cpp-btn-primary">Guardar Configuración</button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
             </div>
         </div>
         
@@ -191,74 +266,6 @@ function cpp_shortcode_cuaderno_notas_classroom() {
 
         <?php
         // --- INICIO DE LA SECCIÓN DE MODALES ---
-
-        if (empty(did_action('cpp_modal_clase_outputted'))) {
-            ?>
-            <div class="cpp-modal" id="cpp-modal-clase">
-                <div class="cpp-modal-content">
-                    <span class="cpp-modal-close">&times;</span>
-                    <h2 id="cpp-modal-clase-titulo">Crear Nueva Clase</h2>
-                    <form id="cpp-form-clase" novalidate>
-                        <input type="hidden" id="clase_id_editar" name="clase_id_editar" value="">
-                        <div class="cpp-tabs-container">
-                            <div class="cpp-tab-nav">
-                                <button type="button" class="cpp-tab-link active" data-tab="cpp-tab-general">General</button>
-                                <button type="button" class="cpp-tab-link" data-tab="cpp-tab-evaluaciones">Evaluaciones</button>
-                                <button type="button" class="cpp-tab-link" data-tab="cpp-tab-ponderaciones">Ponderaciones</button>
-                            </div>
-                            <div id="cpp-tab-general" class="cpp-tab-content active">
-                                <h3>Información General</h3>
-                                <div class="cpp-form-group">
-                                    <label for="nombre_clase_modal">Nombre de la clase (máx. 16 caracteres):</label>
-                                    <input type="text" id="nombre_clase_modal" name="nombre_clase" required maxlength="16">
-                                </div>
-                                <div class="cpp-form-group" id="cpp-opcion-clase-ejemplo-container" style="display: none;">
-                                    <label style="font-weight:normal; display:flex; align-items: center; gap: 8px;">
-                                        <input type="checkbox" id="rellenar_clase_ejemplo" name="rellenar_clase_ejemplo">
-                                        Rellenar la clase con datos de ejemplo
-                                    </label>
-                                </div>
-                                <div class="cpp-form-group">
-                                    <label>Color de la clase:</label>
-                                    <div class="cpp-color-swatches-container">
-                                        <?php foreach ($milan_vivid_colors as $hex => $name): ?>
-                                            <span class="cpp-color-swatch <?php echo (strtoupper($hex) === strtoupper($default_class_color_hex)) ? 'selected' : ''; ?>" data-color="<?php echo esc_attr($hex); ?>" style="background-color: <?php echo esc_attr($hex); ?>;" title="<?php echo esc_attr($name); ?>"></span>
-                                        <?php endforeach; ?>
-                                    </div>
-                                    <input type="hidden" id="color_clase_hidden_modal" name="color_clase" value="<?php echo esc_attr($default_class_color_hex); ?>"> 
-                                </div>
-                                <div class="cpp-form-group">
-                                    <label for="base_nota_final_clase_modal">Base Nota Final (ej: 10, 100):</label>
-                                    <input type="number" id="base_nota_final_clase_modal" name="base_nota_final_clase" value="100" step="0.01" min="1" required>
-                                    <small>La nota final de los alumnos se calculará sobre esta base.</small>
-                                </div>
-                                <div class="cpp-form-group">
-                                    <label for="nota_aprobado_clase_modal">Nota mínima para aprobar (ej: 5, 50):</label>
-                                    <input type="number" id="nota_aprobado_clase_modal" name="nota_aprobado_clase" value="50" step="0.01" min="0" required>
-                                    <small>Los alumnos con una nota final inferior a esta se considerarán suspensos.</small>
-                                </div>
-                            </div>
-                            <div id="cpp-tab-evaluaciones" class="cpp-tab-content">
-                                <div id="cpp-clase-modal-evaluaciones-container">
-                                    <p>Cargando evaluaciones...</p>
-                                </div>
-                            </div>
-                            <div id="cpp-tab-ponderaciones" class="cpp-tab-content">
-                                <div id="cpp-clase-modal-ponderaciones-container">
-                                    <p>Selecciona una evaluación para ver sus ponderaciones.</p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cpp-modal-actions">
-                            <button type="submit" class="cpp-btn cpp-btn-primary cpp-modal-submit-btn" id="cpp-submit-clase-btn-modal"><span class="dashicons dashicons-saved"></span> Guardar Clase</button>
-                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-clase-modal-btn" style="display: none; margin-left: auto;"><span class="dashicons dashicons-trash"></span> Eliminar Clase</button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <?php
-            do_action('cpp_modal_clase_outputted');
-        }
         
         if (empty(did_action('cpp_modal_alumnos_outputted'))) {
             ?>

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -81,6 +81,8 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         <button class="cpp-main-tab-link active" data-tab="cuaderno">Cuaderno</button>
                         <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
                         <button class="cpp-main-tab-link" data-tab="programacion">Programación</button>
+                        <button class="cpp-main-tab-link" data-tab="semana">Semana</button>
+                        <button class="cpp-main-tab-link" data-tab="horario">Horario</button>
                     </div>
                 </div>
                 <div class="cpp-top-bar-right">
@@ -126,6 +128,8 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         </div>
                     </div>
                     <div id="cpp-main-tab-programacion" class="cpp-main-tab-content"></div>
+                    <div id="cpp-main-tab-semana" class="cpp-main-tab-content"></div>
+                    <div id="cpp-main-tab-horario" class="cpp-main-tab-content"></div>
                     <div id="cpp-main-tab-configuracion" class="cpp-main-tab-content">
                         <div class="cpp-config-container">
                             <div class="cpp-config-sidebar">


### PR DESCRIPTION
This commit refactors the class and calendar configuration from modals into a new dedicated "Configuración" main tab.

- Adds a new "Configuración" main tab with "Clase", "Evaluaciones", and "Calendario" sub-tabs.
- Moves the content from the class and calendar settings modals into the new tabbed interface.
- Refactors `cpp-modales-clase.js` into `cpp-configuracion.js` to manage the new UI.
- Updates all related event handlers and function calls to point to the new configuration screen.
- Fixes an issue where modals were not vertically centered by using flexbox for positioning.