### PR TITLE
Refactor: Unify 'Evaluaciones' settings page

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -441,6 +441,20 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
     display: flex;
     flex-direction: column;
 }
+
+.cpp-config-section {
+    padding: 20px;
+    background-color: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    margin-bottom: 25px;
+}
+
+.cpp-config-divider {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 40px 0;
+}
 .cpp-modal-close { position: absolute; top: 12px; right: 12px; font-size: 24px; color: #5f6368; cursor: pointer; line-height: 1; padding: 4px; border-radius: 50%; }
 .cpp-modal-close:hover { color: #202124; background-color: rgba(0,0,0,0.05); }
 .cpp-modal-content h2 { margin-top: 0; margin-bottom: 24px; font-size: 20px; font-weight: 500; color: #202124; flex-shrink: 0; }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -443,17 +443,34 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
 }
 
 .cpp-config-section {
-    padding: 20px;
-    background-color: #f9f9f9;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
+    padding: 10px 0;
+    background-color: #fff;
+    border: none;
     margin-bottom: 25px;
 }
 
 .cpp-config-divider {
     border: none;
-    border-top: 1px solid #ddd;
-    margin: 40px 0;
+    border-top: 1px solid #e0e0e0;
+    margin: 30px 0;
+}
+
+#cpp-ponderaciones-eval-selector {
+    max-width: 400px;
+}
+
+.cpp-config-content-area, .cpp-config-content-area h4, .cpp-config-content-area p, .cpp-config-content-area small, .cpp-config-content-area select, .cpp-config-content-area input {
+    font-size: 15px !important;
+}
+
+.cpp-config-content-area h4 {
+    font-size: 18px !important;
+    font-weight: 500;
+    margin-bottom: 15px;
+}
+
+.cpp-config-content-area p, .cpp-config-content-area small {
+    line-height: 1.6;
 }
 .cpp-modal-close { position: absolute; top: 12px; right: 12px; font-size: 24px; color: #5f6368; cursor: pointer; line-height: 1; padding: 4px; border-radius: 50%; }
 .cpp-modal-close:hover { color: #202124; background-color: rgba(0,0,0,0.05); }
@@ -518,15 +535,15 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
 .cpp-categoria-actions { display: flex; align-items: center; gap: 5px; margin-left: auto; }
 .cpp-btn-editar-categoria .dashicons, .cpp-btn-eliminar-categoria .dashicons { font-size: 18px !important; }
 
-.cpp-modal-content .cpp-categorias-list li span.cpp-category-color-indicator { 
-    display: inline-block !important; 
-    width: 16px !important; 
-    height: 16px !important; 
-    border: 1px solid #ccc !important; 
-    border-radius: 3px !important; 
-    margin-right: 8px !important; 
-    vertical-align: middle !important; 
-    flex-shrink: 0 !important; 
+.cpp-category-color-indicator {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    margin-right: 8px;
+    vertical-align: middle;
+    flex-shrink: 0;
 }
 
 .cpp-categoria-form-actions {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -472,6 +472,17 @@ tr.alumno-suspenso > td { background-color: #fce8e6 !important; }
 .cpp-config-content-area p, .cpp-config-content-area small {
     line-height: 1.6;
 }
+
+.cpp-radio-group label {
+    display: block;
+    margin-bottom: 12px;
+    font-size: 16px !important;
+}
+
+.cpp-radio-group input[type="radio"] {
+    margin-right: 10px;
+    transform: scale(1.2);
+}
 .cpp-modal-close { position: absolute; top: 12px; right: 12px; font-size: 24px; color: #5f6368; cursor: pointer; line-height: 1; padding: 4px; border-radius: 50%; }
 .cpp-modal-close:hover { color: #202124; background-color: rgba(0,0,0,0.05); }
 .cpp-modal-content h2 { margin-top: 0; margin-bottom: 24px; font-size: 20px; font-weight: 500; color: #202124; flex-shrink: 0; }

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -456,10 +456,10 @@
             html += '</ul>';
 
             html += `<div class="cpp-form-add-evaluacion">
-                        <input type="text" id="cpp-nombre-nueva-evaluacion" placeholder="Nombre de la nueva evaluación" style="flex-grow:1;">`;
+                        <input type="text" id="cpp-nombre-nueva-evaluacion" placeholder="Nombre de la nueva evaluación" style="flex-basis: 250px;">`;
 
             if (evaluaciones && evaluaciones.length > 0) {
-                html += `<div class="cpp-form-group" style="margin-bottom:0; flex-basis: 200px;">
+                html += `<div class="cpp-form-group" style="margin-bottom:0; flex-grow: 1;">
                             <select id="cpp-copy-from-eval-select">
                                 <option value="0">No copiar ponderaciones</option>`;
                 evaluaciones.forEach(function(evaluacion_origen) {

--- a/assets/js/cpp-configuracion.js
+++ b/assets/js/cpp-configuracion.js
@@ -381,22 +381,9 @@
             $(`#cpp-config-tab-${tabId}`).addClass('active');
         },
 
-        handleInnerTabClick: function(event) {
-            if (event) event.preventDefault();
-            const $clickedLink = $(event.currentTarget);
-            const $tabsContainer = $clickedLink.closest('.cpp-tabs-container');
-            const tabId = $clickedLink.data('tab');
-
-            $tabsContainer.find('.cpp-tab-link').removeClass('active');
-            $tabsContainer.find('.cpp-tab-content').removeClass('active');
-
-            $clickedLink.addClass('active');
-            $tabsContainer.find('#' + tabId).addClass('active');
-        },
-
         loadPonderacionesTab: function(claseId) {
             const $container = $('#cpp-config-ponderaciones-container');
-            $container.html('<p class="cpp-cuaderno-cargando">Cargando evaluaciones...</p>');
+            $container.html('<p class="cpp-cuaderno-cargando">Cargando tipos de ponderación y categorías...</p>');
 
             $.ajax({
                 url: cppFrontendData.ajaxUrl,
@@ -405,7 +392,7 @@
                 data: { action: 'cpp_obtener_evaluaciones', nonce: cppFrontendData.nonce, clase_id: claseId },
                 success: function(response) {
                     if (response.success && response.data.evaluaciones && response.data.evaluaciones.length > 0) {
-                        let contentHtml = '<h4>Selecciona una evaluación para gestionar sus ponderaciones</h4>';
+                        let contentHtml = '<h4>Tipos de ponderación y categorías</h4>';
                         contentHtml += '<div class="cpp-form-group"><select id="cpp-ponderaciones-eval-selector" class="cpp-evaluacion-selector">';
                         contentHtml += '<option value="">-- Selecciona --</option>';
                         response.data.evaluaciones.forEach(function(evaluacion) {
@@ -415,7 +402,7 @@
                         contentHtml += '<div id="cpp-ponderaciones-settings-content"></div>';
                         $container.html(contentHtml);
                     } else {
-                        $container.html('<p>No hay evaluaciones creadas para esta clase. Añade una en la pestaña "Evaluaciones".</p>');
+                        $container.html('<h4>Tipos de ponderación y categorías</h4><p>No hay evaluaciones creadas para esta clase. Añade una evaluación primero para poder gestionar sus ponderaciones y categorías.</p>');
                     }
                 },
                 error: function() {
@@ -505,7 +492,6 @@
 
             // --- Eventos de la Pestaña de Configuración ---
             $mainContent.on('click', '.cpp-config-tab-link', (e) => { this.handleConfigTabClick(e); });
-            $mainContent.on('click', '#cpp-config-tab-evaluaciones .cpp-tab-link', (e) => { this.handleInnerTabClick(e); });
 
             // Guardar/Eliminar desde la pestaña de configuración
             $mainContent.on('submit', '#cpp-form-clase', (e) => { this.guardar(e); });

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -190,22 +190,12 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                                     </form>
                                 </div>
                                 <div id="cpp-config-tab-evaluaciones" class="cpp-config-tab-content">
-                                    <h2>Evaluaciones y Ponderaciones</h2>
-                                    <div class="cpp-tabs-container">
-                                        <div class="cpp-tab-nav">
-                                            <button type="button" class="cpp-tab-link active" data-tab="cpp-tab-evaluaciones-config">Evaluaciones de la clase</button>
-                                            <button type="button" class="cpp-tab-link" data-tab="cpp-tab-ponderaciones-config">Tipo de ponderación y categorías</button>
-                                        </div>
-                                        <div id="cpp-tab-evaluaciones-config" class="cpp-tab-content active">
-                                            <div id="cpp-config-evaluaciones-container">
-                                                <p>Cargando evaluaciones...</p>
-                                            </div>
-                                        </div>
-                                        <div id="cpp-tab-ponderaciones-config" class="cpp-tab-content">
-                                            <div id="cpp-config-ponderaciones-container">
-                                                <p>Selecciona una evaluación para ver sus ponderaciones.</p>
-                                            </div>
-                                        </div>
+                                    <div id="cpp-config-evaluaciones-container" class="cpp-config-section">
+                                        <p>Cargando evaluaciones...</p>
+                                    </div>
+                                    <hr class="cpp-config-divider">
+                                    <div id="cpp-config-ponderaciones-container" class="cpp-config-section">
+                                        <p>Selecciona una evaluación para ver sus ponderaciones.</p>
                                     </div>
                                 </div>
                                 <div id="cpp-config-tab-calendario" class="cpp-config-tab-content">

--- a/jules-scratch/verification/verify_evaluaciones_page.py
+++ b/jules-scratch/verification/verify_evaluaciones_page.py
@@ -1,0 +1,43 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # The base URL needs to be provided
+    base_url = "http://localhost:8000"
+
+    # Log in
+    page.goto(f"{base_url}/wp-login.php")
+    page.fill('input[name="log"]', "admin")
+    page.fill('input[name="pwd"]', "admin")
+    page.click('input[name="wp-submit"]')
+    page.wait_for_load_state("networkidle")
+
+    # Go to the plugin page
+    page.goto(f"{base_url}/wp-admin/admin.php?page=cuaderno-para-profes")
+    page.wait_for_load_state("networkidle")
+
+    # Click on the first class to open the settings
+    page.click('.cpp-sidebar-clase-item')
+    page.wait_for_load_state("networkidle")
+
+    # Click on the settings button for the first class
+    page.click('.cpp-sidebar-clase-settings-btn')
+    page.wait_for_load_state("networkidle")
+
+    # Click on the "Evaluaciones" tab
+    page.click('a[data-config-tab="evaluaciones"]')
+    page.wait_for_load_state("networkidle")
+
+    # Take a screenshot
+    screenshot_path = "jules-scratch/verification/verification.png"
+    page.screenshot(path=screenshot_path)
+
+    print(f"Screenshot saved to {screenshot_path}")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
- Removes the sub-tabs for 'Evaluaciones de la clase' and 'Tipos de ponderación y categorías'.
- Merges the content of both sub-tabs into a single, scrollable view.
- Adds CSS to improve spacing and readability as per user request.
- Updates JavaScript to remove the now-unnecessary tab handling logic.