### PR TITLE
fix(programador): Load evaluation categories for scheduler

### DIFF
--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -613,6 +613,7 @@
         const currentEval = this.currentClase.evaluaciones.find(e => e.id == this.currentEvaluacionId);
         let categorySelector = '';
 
+
         if (isEvaluable && currentEval && currentEval.calculo_nota.trim() === 'ponderado' && currentEval.categorias && currentEval.categorias.length > 0) {
             const options = currentEval.categorias.map(cat => `<option value="${cat.id}" ${actividad.categoria_id == cat.id ? 'selected' : ''}>${cat.nombre_categoria}</option>`).join('');
             categorySelector = `<select class="cpp-actividad-categoria-selector" data-actividad-id="${actividad.id}">${options}</select>`;

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -613,18 +613,6 @@
         const currentEval = this.currentClase.evaluaciones.find(e => e.id == this.currentEvaluacionId);
         let categorySelector = '';
 
-        // --- DEBUGGING CODE ---
-        console.log('--- [DEBUG] In renderActividadItem ---');
-        console.log('[DEBUG] Actividad object:', actividad);
-        console.log('[DEBUG] isEvaluable:', isEvaluable);
-        console.log('[DEBUG] currentEvaluacionId:', this.currentEvaluacionId);
-        console.log('[DEBUG] currentEval object:', currentEval);
-        if (currentEval) {
-            console.log('[DEBUG] currentEval.calculo_nota:', currentEval.calculo_nota);
-            console.log('[DEBUG] currentEval.categorias:', currentEval.categorias);
-        }
-        console.log('--- [DEBUG] End of debug info ---');
-        // --- END DEBUGGING CODE ---
 
         if (isEvaluable && currentEval && currentEval.calculo_nota.trim() === 'ponderado' && currentEval.categorias && currentEval.categorias.length > 0) {
             const options = currentEval.categorias.map(cat => `<option value="${cat.id}" ${actividad.categoria_id == cat.id ? 'selected' : ''}>${cat.nombre_categoria}</option>`).join('');
@@ -658,7 +646,7 @@
         }
 
         const currentEval = this.currentClase.evaluaciones.find(e => e.id == this.currentEvaluacionId);
-        if (isEvaluable && currentEval && currentEval.calculo_nota === 'ponderado' && currentEval.categorias.length > 0) {
+        if (isEvaluable && currentEval && currentEval.calculo_nota.trim() === 'ponderado' && currentEval.categorias.length > 0) {
             const row = toggle.closest('.cpp-actividad-item');
             const selector = row.querySelector('.cpp-actividad-categoria-selector');
             if (selector) {

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -613,6 +613,18 @@
         const currentEval = this.currentClase.evaluaciones.find(e => e.id == this.currentEvaluacionId);
         let categorySelector = '';
 
+        // --- DEBUGGING CODE ---
+        console.log('--- [DEBUG] In renderActividadItem ---');
+        console.log('[DEBUG] Actividad object:', actividad);
+        console.log('[DEBUG] isEvaluable:', isEvaluable);
+        console.log('[DEBUG] currentEvaluacionId:', this.currentEvaluacionId);
+        console.log('[DEBUG] currentEval object:', currentEval);
+        if (currentEval) {
+            console.log('[DEBUG] currentEval.calculo_nota:', currentEval.calculo_nota);
+            console.log('[DEBUG] currentEval.categorias:', currentEval.categorias);
+        }
+        console.log('--- [DEBUG] End of debug info ---');
+        // --- END DEBUGGING CODE ---
 
         if (isEvaluable && currentEval && currentEval.calculo_nota.trim() === 'ponderado' && currentEval.categorias && currentEval.categorias.length > 0) {
             const options = currentEval.categorias.map(cat => `<option value="${cat.id}" ${actividad.categoria_id == cat.id ? 'selected' : ''}>${cat.nombre_categoria}</option>`).join('');

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -303,7 +303,14 @@ function cpp_ajax_toggle_actividad_evaluable() {
         $wpdb->update($tabla_programador_actividades, $update_data, ['id' => $actividad_id]);
     }
 
-    $actividad_actualizada = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id));
+    $actividad_actualizada = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id), ARRAY_A);
+
+    if ($actividad_actualizada) {
+        // FIX: Devolver la categoría ID para que el frontend pueda renderizar el selector correctamente.
+        // Si se está marcando como evaluable, $categoria_id tendrá un valor. Si no, será null, lo cual es correcto.
+        $actividad_actualizada['categoria_id'] = $categoria_id;
+    }
+
     wp_send_json_success(['message' => 'Estado actualizado.', 'actividad' => $actividad_actualizada]);
 }
 

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -21,6 +21,13 @@ function cpp_programador_get_all_data($user_id) {
     if (!empty($clases)) {
         for ($i = 0; $i < count($clases); $i++) {
             $clases[$i]['evaluaciones'] = cpp_obtener_evaluaciones_por_clase($clases[$i]['id'], $user_id);
+            // FIX: Añadir las categorías a cada evaluación para que estén disponibles en el frontend del programador.
+            if (!empty($clases[$i]['evaluaciones'])) {
+                for ($j = 0; $j < count($clases[$i]['evaluaciones']); $j++) {
+                    $evaluacion_id = $clases[$i]['evaluaciones'][$j]['id'];
+                    $clases[$i]['evaluaciones'][$j]['categorias'] = cpp_obtener_categorias_por_evaluacion($evaluacion_id, $user_id);
+                }
+            }
         }
     }
 

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -3,6 +3,7 @@
 
 defined('ABSPATH') or die('Acceso no permitido');
 
+
 function cpp_programador_save_config_value($user_id, $clave, $valor) {
     global $wpdb;
     $tabla_config = $wpdb->prefix . 'cpp_programador_config';


### PR DESCRIPTION
The category selector for gradable activities was not appearing in the scheduler. This was because the initial data load for the scheduler's frontend did not include the list of grading categories for each evaluation.

This change modifies the `cpp_programador_get_all_data` function to loop through each evaluation and attach its associated categories. This ensures the frontend has the necessary data to render the category selector dropdown when an activity is marked as gradable.