### PR TITLE
Fix(config): Update config tab on class change and redesign tabs

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1714,42 +1714,82 @@ body.cpp-no-text-select {
 .cpp-top-bar-center {
     flex-grow: 1;
     display: flex;
-    justify-content: center;
-    align-items: flex-end; /* Alinea las pestañas en la parte inferior de la barra */
+    justify-content: flex-start; /* Cambio para alinear a la izquierda */
+    align-items: flex-end;
+    height: 100%;
 }
 
 .cpp-main-tabs-nav {
     display: flex;
+    align-items: flex-end;
+    width: 100%;
+    gap: 10px;
+}
+
+.cpp-tabs-clase-specific {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding-left: 20px;
+}
+
+.cpp-tabs-general {
+    display: flex;
+    background-color: #fff;
+    padding: 5px 5px 0 5px;
+    border-radius: 8px 8px 0 0;
+    border: 1px solid #e0e0e0;
+    border-bottom: none;
+    align-self: flex-end;
 }
 
 .cpp-main-tab-link {
-    padding: 10px 24px;
+    padding: 8px 16px;
     cursor: pointer;
-    border: 1px solid transparent;
-    border-bottom: none;
-    background-color: rgba(0,0,0,0.05);
+    border: none;
+    background-color: transparent;
     color: inherit;
-    opacity: 0.7;
+    opacity: 0.8;
     font-size: 14px;
     font-weight: 500;
-    border-radius: 8px 8px 0 0;
-    margin: 0 4px;
-    position: relative;
-    bottom: -1px; /* Para que se solape con el borde del contenido */
+    border-radius: 6px;
+    margin: 0 2px;
     transition: all 0.2s ease-in-out;
+    border-bottom: 3px solid transparent;
 }
 
 .cpp-main-tab-link:hover {
     opacity: 1;
-    background-color: rgba(0,0,0,0.1);
+    background-color: rgba(255, 255, 255, 0.2);
 }
 
-.cpp-main-tab-link.active {
-    background-color: #fff; /* El color del área de contenido */
-    color: #333; /* Texto oscuro para la pestaña activa */
+/* Pestañas de clase activa */
+.cpp-tabs-clase-specific .cpp-main-tab-link.active {
     opacity: 1;
-    border-color: #e0e0e0;
     font-weight: 600;
+    background-color: rgba(255, 255, 255, 0.25);
+    border-bottom: 3px solid;
+}
+
+/* Pestañas generales */
+.cpp-tabs-general .cpp-main-tab-link {
+    color: #333;
+    opacity: 0.7;
+    padding-bottom: 5px;
+    margin-bottom: 3px;
+}
+
+.cpp-tabs-general .cpp-main-tab-link:hover {
+    opacity: 1;
+    background-color: #f0f0f0;
+}
+
+.cpp-tabs-general .cpp-main-tab-link.active {
+    color: #1a73e8;
+    opacity: 1;
+    font-weight: 600;
+    background-color: transparent;
+    border-bottom: 3px solid #1a73e8;
 }
 
 /* Contenedor principal de los contenidos de las pestañas */

--- a/assets/js/cpp-sidebar.js
+++ b/assets/js/cpp-sidebar.js
@@ -128,6 +128,13 @@
                 }
             }
 
+            // --- FIX: Notificar a la pestaña de configuración del cambio de clase ---
+            if (jQuery('.cpp-main-tab-link[data-tab="configuracion"]').hasClass('active')) {
+                if (cpp.config && typeof cpp.config.showParaEditar === 'function') {
+                    cpp.config.showParaEditar(null, false, claseId);
+                }
+            }
+
             if (cpp.sidebar.isSidebarVisible) { 
                 cpp.sidebar.toggle(); 
             }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -78,11 +78,15 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                 </div>
                 <div class="cpp-top-bar-center">
                     <div class="cpp-main-tabs-nav">
-                        <button class="cpp-main-tab-link active" data-tab="cuaderno">Cuaderno</button>
-                        <button class="cpp-main-tab-link" data-tab="programacion">Programación</button>
-                        <button class="cpp-main-tab-link" data-tab="semana">Semana</button>
-                        <button class="cpp-main-tab-link" data-tab="horario">Horario</button>
-                        <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
+                        <div class="cpp-tabs-clase-specific">
+                            <button class="cpp-main-tab-link active" data-tab="cuaderno">Cuaderno</button>
+                            <button class="cpp-main-tab-link" data-tab="programacion">Programación</button>
+                            <button class="cpp-main-tab-link" data-tab="configuracion">Configuración</button>
+                        </div>
+                        <div class="cpp-tabs-general">
+                            <button class="cpp-main-tab-link" data-tab="semana">Semana</button>
+                            <button class="cpp-main-tab-link" data-tab="horario">Horario</button>
+                        </div>
                     </div>
                 </div>
                 <div class="cpp-top-bar-right">

--- a/jules-scratch/verification/verify_tabs_and_config_fix.py
+++ b/jules-scratch/verification/verify_tabs_and_config_fix.py
@@ -1,0 +1,61 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(page: Page):
+    """
+    This script verifies two things:
+    1. The main tabs are visually separated into two groups.
+    2. The 'Configuración' tab correctly updates when the class is changed.
+    """
+    # Go to the page where the shortcode is active
+    # Trying a cleaner URL structure
+    page.goto("http://localhost:8000/cuaderno-de-notas-2", wait_until="networkidle")
+
+    # 1. Verify the UI change
+    # Take a screenshot of the initial state to show the new tab layout
+
+    # Wait for the first class to load to ensure the app is ready
+    expect(page.locator("#cpp-cuaderno-nombre-clase-activa-a1")).not_to_be_empty()
+
+    # 2. Verify the bug fix
+    # Click on the 'Configuración' tab
+    config_tab_button = page.locator('.cpp-main-tab-link[data-tab="configuracion"]')
+    config_tab_button.click()
+
+    # Wait for the configuration form to be populated for the first class
+    # The title of the config section changes to "Editar Clase: <nombre>"
+    expect(page.locator("#cpp-config-clase-titulo")).to_contain_text("Editar Clase:")
+
+    # Get the name of the first class from the sidebar
+    first_class_name = page.locator(".cpp-sidebar-clase-item").first.get_attribute("data-clase-nombre")
+
+    # Check that the form title matches the first class
+    expect(page.locator("#cpp-config-clase-titulo")).to_have_text(f"Editar Clase: {first_class_name}")
+
+    # Now, click the second class in the sidebar
+    second_class_item = page.locator(".cpp-sidebar-clase-item").nth(1)
+    second_class_name = second_class_item.get_attribute("data-clase-nombre")
+
+    # Make sure we're clicking a different class
+    if first_class_name == second_class_name:
+        print("Warning: Cannot verify bug fix because there is only one class or the first two classes have the same name.")
+    else:
+        second_class_item.locator("a").click()
+        # After clicking, the sidebar might close, and content will reload.
+        # We need to wait for the config form to be updated with the second class name.
+        expect(page.locator("#cpp-config-clase-titulo")).to_have_text(f"Editar Clase: {second_class_name}")
+
+    # Take a final screenshot to show the result
+    screenshot_path = "jules-scratch/verification/verification.png"
+    page.screenshot(path=screenshot_path, full_page=True)
+    print(f"Screenshot saved to {screenshot_path}")
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        run(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit addresses two main points:

1.  **Bug Fix:** The 'Configuración' tab now correctly updates its content when the active class is changed from the sidebar. This is achieved by adding a check in the class selection handler to call the appropriate update function if the configuration tab is active.

2.  **UI Improvement:** The main navigation tabs have been visually redesigned to better distinguish between class-specific tabs and general tabs.
    - 'Cuaderno', 'Programación', and 'Configuración' are now grouped and styled to appear integrated with the colored class bar.
    - 'Semana' and 'Horario' are grouped separately on a white background to clarify their general nature.

These changes improve the user experience by fixing a reactivity bug and providing a clearer visual hierarchy for the application's navigation.