### PR TITLE
feat: Persist and sync evaluation state across tabs

### DIFF
--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -299,6 +299,12 @@
                         }
                     }
                 }
+                    // Renderizar la pestaña de la semana bajo demanda
+                    if (tabName === 'semana') {
+                        if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.renderSemanaTab === 'function') {
+                            CppProgramadorApp.renderSemanaTab();
+                        }
+                    }
             } else if (tabName === 'configuracion') {
                 if (cpp.config && typeof cpp.config.showParaEditar === 'function') {
                     if (cpp.currentClaseIdCuaderno) {

--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -309,6 +309,23 @@
                         cpp.config.resetForm();
                     }
                 }
+            } else if (tabName === 'cuaderno') {
+                // Sincronizar el cuaderno si la evaluación ha cambiado en otra pestaña
+                if (cpp.currentClaseIdCuaderno) {
+                    const localStorageKey = this.localStorageKey_lastEval + cpp.currentClaseIdCuaderno;
+                    let lastEvalIdFromStorage = null;
+                    try {
+                        lastEvalIdFromStorage = localStorage.getItem(localStorageKey);
+                    } catch (e) {
+                        console.warn("No se pudo leer de localStorage:", e);
+                    }
+
+                    if (lastEvalIdFromStorage && lastEvalIdFromStorage !== cpp.currentEvaluacionId) {
+                        console.log(`Sincronizando cuaderno a la evaluación ${lastEvalIdFromStorage} desde localStorage.`);
+                        const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
+                        this.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, lastEvalIdFromStorage);
+                    }
+                }
             }
         },
 

--- a/assets/js/cpp-modales-actividad.js
+++ b/assets/js/cpp-modales-actividad.js
@@ -28,7 +28,7 @@
             }
         },
 
-        mostrarAnadir: function(sesionId = null) {
+        mostrarAnadir: function(sesionId = null, calculatedDate = null) {
             if (!cpp.currentClaseIdCuaderno || !cpp.currentEvaluacionId) {
                 alert('Por favor, selecciona una clase y una evaluación válidas para añadir la actividad.');
                 return;
@@ -36,6 +36,7 @@
             
             this.resetForm(); 
             $('#clase_id_actividad_cuaderno_form').val(cpp.currentClaseIdCuaderno);
+            $('#fecha_actividad_cuaderno_input').val(calculatedDate || ''); // Poner la fecha calculada
             if (sesionId) {
                 $('#sesion_id_cuaderno').val(sesionId);
             }

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -664,7 +664,6 @@
     render() {
         if (!this.currentClase) { this.tabContents.programacion.innerHTML = '<p class="cpp-empty-panel">Cargando...</p>'; return; }
         this.renderProgramacionTab();
-        this.renderSemanaTab();
         this.renderHorarioTab();
     },
     renderProgramacionTab() {

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -79,9 +79,10 @@ function cpp_ajax_delete_programador_sesion() {
     check_ajax_referer('cpp_frontend_nonce', 'nonce');
     if (!is_user_logged_in()) { wp_send_json_error(['message' => 'Usuario no autenticado.']); return; }
     $sesion_id = isset($_POST['sesion_id']) ? intval($_POST['sesion_id']) : 0;
+    $delete_activities = isset($_POST['delete_activities']) && $_POST['delete_activities'] === 'true'; // El 'true' viene como string
     if (empty($sesion_id)) { wp_send_json_error(['message' => 'ID de sesión no proporcionado.']); return; }
     $user_id = get_current_user_id();
-    if (cpp_programador_delete_sesion($sesion_id, $user_id)) { wp_send_json_success(['message' => 'Sesión eliminada.']); }
+    if (cpp_programador_delete_sesion($sesion_id, $user_id, $delete_activities)) { wp_send_json_success(['message' => 'Sesión eliminada.']); }
     else { wp_send_json_error(['message' => 'Error al eliminar la sesión.']); }
 }
 

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -252,6 +252,121 @@ function cpp_programador_add_sesion_inline($sesion_data, $after_sesion_id, $user
     return $wpdb->insert_id;
 }
 
+// --- Funciones de Lógica de Horario ---
+
+/**
+ * Calculates all the dates for a given evaluation's sessions based on a start date and schedule.
+ *
+ * @param array $sesiones_en_evaluacion Array of session objects for the evaluation.
+ * @param string $start_date_str The start date in 'Y-m-d' format.
+ * @param array $horario The user's schedule.
+ * @param array $calendar_config The user's calendar config (working_days, holidays, vacations).
+ * @param int $clase_id The ID of the class.
+ * @return array An array of calculated dates for each session, e.g., ['2025-09-15_09:00', '2025-09-15_10:00'].
+ */
+function cpp_programador_calculate_schedule_for_evaluation($sesiones_en_evaluacion, $start_date_str, $horario, $calendar_config, $clase_id) {
+    if (empty($start_date_str) || empty($sesiones_en_evaluacion) || empty($horario)) {
+        return [];
+    }
+
+    $schedule = [];
+
+    try {
+        $current_date = new DateTime($start_date_str . 'T12:00:00Z');
+    } catch (Exception $e) {
+        return []; // Invalid date format
+    }
+
+    $session_index = 0;
+    $safety_counter = 0;
+    $max_iterations = 365 * 5; // 5 years of margin
+
+    while ($session_index < count($sesiones_en_evaluacion) && $safety_counter < $max_iterations) {
+        $day_key = strtolower($current_date->format('D')); // mon, tue, etc.
+        $ymd = $current_date->format('Y-m-d');
+
+        $is_working_day = in_array($day_key, $calendar_config['working_days']);
+        $is_holiday = in_array($ymd, $calendar_config['holidays']);
+        $is_vacation = false;
+        if (!empty($calendar_config['vacations'])) {
+            foreach ($calendar_config['vacations'] as $v) {
+                if ($ymd >= $v['start'] && $ymd <= $v['end']) {
+                    $is_vacation = true;
+                    break;
+                }
+            }
+        }
+
+        if ($is_working_day && !$is_holiday && !$is_vacation && isset($horario[$day_key])) {
+            $slots_del_dia = $horario[$day_key];
+            ksort($slots_del_dia);
+
+            foreach ($slots_del_dia as $slot => $slot_data) {
+                if (isset($slot_data['claseId']) && strval($slot_data['claseId']) === strval($clase_id)) {
+                    if ($session_index < count($sesiones_en_evaluacion)) {
+                        $schedule[] = $ymd . '_' . $slot;
+                        $session_index++;
+                    }
+                }
+            }
+        }
+
+        $current_date->add(new DateInterval('P1D'));
+        $safety_counter++;
+    }
+
+    return $schedule;
+}
+
+/**
+ * Checks if a proposed start date for an evaluation causes a schedule conflict.
+ *
+ * @param int $user_id
+ * @param int $evaluacion_id_a_chequear The evaluation being changed.
+ * @param string $nueva_start_date The proposed new start date.
+ * @return bool True if there is a conflict, false otherwise.
+ */
+function cpp_programador_check_schedule_conflict($user_id, $evaluacion_id_a_chequear, $nueva_start_date) {
+    global $wpdb;
+    $all_data = cpp_programador_get_all_data($user_id);
+
+    $clase_id = $wpdb->get_var($wpdb->prepare("SELECT clase_id FROM {$wpdb->prefix}cpp_evaluaciones WHERE id = %d AND user_id = %d", $evaluacion_id_a_chequear, $user_id));
+    if (!$clase_id) return false;
+
+    $sesiones_de_la_clase = array_filter($all_data['sesiones'], function($sesion) use ($clase_id) {
+        return $sesion->clase_id == $clase_id;
+    });
+
+    $occupied_slots = [];
+
+    $otras_evaluaciones = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, start_date FROM {$wpdb->prefix}cpp_evaluaciones WHERE clase_id = %d AND id != %d AND user_id = %d",
+        $clase_id, $evaluacion_id_a_chequear, $user_id
+    ));
+
+    foreach ($otras_evaluaciones as $eval) {
+        if (!empty($eval->start_date)) {
+            $sesiones_de_esta_eval = array_filter($sesiones_de_la_clase, function($sesion) use ($eval) {
+                return $sesion->evaluacion_id == $eval->id;
+            });
+            $schedule = cpp_programador_calculate_schedule_for_evaluation(array_values($sesiones_de_esta_eval), $eval->start_date, $all_data['config']['horario'], $all_data['config']['calendar_config'], $clase_id);
+            $occupied_slots = array_merge($occupied_slots, $schedule);
+        }
+    }
+
+    $occupied_slots = array_unique($occupied_slots);
+
+    $sesiones_a_chequear = array_filter($sesiones_de_la_clase, function($sesion) use ($evaluacion_id_a_chequear) {
+        return $sesion->evaluacion_id == $evaluacion_id_a_chequear;
+    });
+    $proposed_schedule = cpp_programador_calculate_schedule_for_evaluation(array_values($sesiones_a_chequear), $nueva_start_date, $all_data['config']['horario'], $all_data['config']['calendar_config'], $clase_id);
+
+    $conflict = array_intersect($proposed_schedule, $occupied_slots);
+
+    return !empty($conflict);
+}
+
+
 // --- Funciones CRUD para Actividades del Programador ---
 
 function cpp_programador_get_actividades_by_sesion_id($sesion_id, $user_id) {


### PR DESCRIPTION
This commit implements a robust state management system for the selected evaluation to address workflow issues.

Key changes:
- The selected evaluation is now saved to localStorage on a per-class basis.
- The application now correctly loads the last selected evaluation on page reload.
- The "cuaderno" (notebook) and "programador" (scheduler) tabs are now synchronized. Changing the evaluation in one tab will reflect in the other.
- When a new session is created in the scheduler, it is now automatically selected and displayed, and the selected evaluation is preserved.

These changes resolve the user's reported issues of losing context when switching tabs, reloading the page, or creating new sessions, leading to a much smoother and more intuitive workflow.