### PR TITLE
feat: Select activity title on creation

### DIFF
--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -291,9 +291,12 @@
                          $('#cpp-main-tab-programacion, #cpp-main-tab-semana, #cpp-main-tab-horario').html('<p class="cpp-empty-panel" style="color:red;">Error: No se pudo cargar el componente del programador.</p>');
                     }
                 } else {
-                    // Si ya está inicializado, siempre recargamos los datos para asegurar que están sincronizados
-                    if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.fetchData === 'function') {
-                         CppProgramadorApp.fetchData(cpp.currentClaseIdCuaderno);
+                    // Si ya está inicializado, solo asegúrate de que tiene la clase correcta
+                    if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.loadClass === 'function') {
+                        // Solo cargar la clase si es diferente a la actual para no perder el estado
+                        if (!CppProgramadorApp.currentClase || CppProgramadorApp.currentClase.id != cpp.currentClaseIdCuaderno) {
+                            CppProgramadorApp.loadClass(cpp.currentClaseIdCuaderno);
+                        }
                     }
                 }
                     // Renderizar la pestaña de la semana bajo demanda
@@ -313,12 +316,21 @@
                     }
                 }
             } else if (tabName === 'cuaderno') {
-                // Siempre recargar el cuaderno para asegurar que los datos (evaluaciones, etc.) están actualizados.
+                // Sincronizar el cuaderno si la evaluación ha cambiado en otra pestaña
                 if (cpp.currentClaseIdCuaderno) {
-                    const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
-                    // Cargar la última evaluación vista para esta clase desde localStorage, o la primera por defecto.
-                    const lastEvalId = localStorage.getItem(this.localStorageKey_lastEval + cpp.currentClaseIdCuaderno);
-                    self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, lastEvalId);
+                    const localStorageKey = this.localStorageKey_lastEval + cpp.currentClaseIdCuaderno;
+                    let lastEvalIdFromStorage = null;
+                    try {
+                        lastEvalIdFromStorage = localStorage.getItem(localStorageKey);
+                    } catch (e) {
+                        console.warn("No se pudo leer de localStorage:", e);
+                    }
+
+                    if (lastEvalIdFromStorage && lastEvalIdFromStorage !== cpp.currentEvaluacionId) {
+                        console.log(`Sincronizando cuaderno a la evaluación ${lastEvalIdFromStorage} desde localStorage.`);
+                        const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
+                        this.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, lastEvalIdFromStorage);
+                    }
                 }
             }
         },
@@ -423,22 +435,6 @@
                     const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
                     // Usar cpp.currentEvaluacionId que ya debería estar actualizado
                     self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, cpp.currentEvaluacionId);
-                }
-            });
-
-            $document.on('cpp:evaluacionCreada', function(e, data) {
-                // Cuando se crea una evaluación, tenemos que actualizar los componentes que la muestran.
-                if (data.claseId && cpp.currentClaseIdCuaderno == data.claseId) {
-                    console.log('Nueva evaluación creada, actualizando vistas...');
-
-                    // 1. Recargar el cuaderno para que muestre la nueva evaluación en el selector.
-                    const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
-                    self.cargarContenidoCuaderno(data.claseId, claseNombre, data.newEvalId);
-
-                    // 2. Si el programador ya ha sido inicializado, recargarlo también.
-                    if (typeof CppProgramadorApp !== 'undefined' && self.programadorInicializado) {
-                        CppProgramadorApp.fetchData(data.claseId, data.newEvalId);
-                    }
                 }
             });
 

--- a/assets/js/cpp-cuaderno.js
+++ b/assets/js/cpp-cuaderno.js
@@ -291,12 +291,9 @@
                          $('#cpp-main-tab-programacion, #cpp-main-tab-semana, #cpp-main-tab-horario').html('<p class="cpp-empty-panel" style="color:red;">Error: No se pudo cargar el componente del programador.</p>');
                     }
                 } else {
-                    // Si ya está inicializado, solo asegúrate de que tiene la clase correcta
-                    if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.loadClass === 'function') {
-                        // Solo cargar la clase si es diferente a la actual para no perder el estado
-                        if (!CppProgramadorApp.currentClase || CppProgramadorApp.currentClase.id != cpp.currentClaseIdCuaderno) {
-                            CppProgramadorApp.loadClass(cpp.currentClaseIdCuaderno);
-                        }
+                    // Si ya está inicializado, siempre recargamos los datos para asegurar que están sincronizados
+                    if (typeof CppProgramadorApp !== 'undefined' && typeof CppProgramadorApp.fetchData === 'function') {
+                         CppProgramadorApp.fetchData(cpp.currentClaseIdCuaderno);
                     }
                 }
                     // Renderizar la pestaña de la semana bajo demanda
@@ -435,6 +432,16 @@
                     const claseNombre = $('#cpp-cuaderno-nombre-clase-activa-a1').text();
                     // Usar cpp.currentEvaluacionId que ya debería estar actualizado
                     self.cargarContenidoCuaderno(cpp.currentClaseIdCuaderno, claseNombre, cpp.currentEvaluacionId);
+                }
+            });
+
+            $document.on('cpp:evaluacionCreada', function(e, data) {
+                if (typeof CppProgramadorApp !== 'undefined' && self.programadorInicializado) {
+                    // Si el programador está visible y la nueva evaluación pertenece a la clase actual, recargar
+                    if (CppProgramadorApp.currentClase && CppProgramadorApp.currentClase.id == data.claseId) {
+                        console.log('Nueva evaluación creada, recargando programador...');
+                        CppProgramadorApp.fetchData(data.claseId, data.newEvalId);
+                    }
                 }
             });
 

--- a/assets/js/cpp-modales-actividad.js
+++ b/assets/js/cpp-modales-actividad.js
@@ -34,12 +34,23 @@
                 return;
             }
             
-            this.resetForm(); 
+            this.resetForm();
             $('#nombre_actividad_cuaderno_input').val('Nueva Actividad Evaluable');
             $('#clase_id_actividad_cuaderno_form').val(cpp.currentClaseIdCuaderno);
-            $('#fecha_actividad_cuaderno_input').val(calculatedDate || ''); // Poner la fecha calculada
+
+            const $fechaInput = $('#fecha_actividad_cuaderno_input');
+            const $fechaGroup = $fechaInput.closest('.cpp-form-group');
+
             if (sesionId) {
+                // Vinculada a la programación: fecha no editable
+                $fechaInput.val(calculatedDate || '').prop('readonly', true);
+                $fechaGroup.addClass('cpp-readonly').attr('title', 'La fecha es gestionada automáticamente por la Programación.');
                 $('#sesion_id_cuaderno').val(sesionId);
+            } else {
+                // No vinculada: fecha editable
+                $fechaInput.val('').prop('readonly', false);
+                $fechaGroup.removeClass('cpp-readonly').attr('title', '');
+                $('#sesion_id_cuaderno').val('');
             }
 
             const $form = $('#cpp-form-actividad-evaluable-cuaderno');
@@ -114,7 +125,19 @@
             $form.find('#actividad_id_editar_cuaderno').val(actividadId);
             $form.find('#nombre_actividad_cuaderno_input').val(nombreActividad);
             $form.find('#nota_maxima_actividad_cuaderno_input').val(parseFloat(notaMaxima).toFixed(2));
-            $form.find('#fecha_actividad_cuaderno_input').val(fechaActividad ? fechaActividad.split(' ')[0] : '');
+
+            const $fechaInput = $form.find('#fecha_actividad_cuaderno_input');
+            const $fechaGroup = $fechaInput.closest('.cpp-form-group');
+            $fechaInput.val(fechaActividad ? fechaActividad.split(' ')[0] : '');
+
+            if (idActividadProgramada && idActividadProgramada !== 'null' && idActividadProgramada !== '') {
+                 $fechaInput.prop('readonly', true);
+                 $fechaGroup.addClass('cpp-readonly').attr('title', 'La fecha es gestionada automáticamente por la Programación.');
+            } else {
+                 $fechaInput.prop('readonly', false);
+                 $fechaGroup.removeClass('cpp-readonly').attr('title', '');
+            }
+
             $form.find('#descripcion_actividad_cuaderno_textarea').val(descripcionActividad);
             $form.find('#clase_id_actividad_cuaderno_form').val(cpp.currentClaseIdCuaderno);
 
@@ -227,7 +250,19 @@
             $form.find('#sesion_id_cuaderno').val(actividad.sesion_id);
             $form.find('#nombre_actividad_cuaderno_input').val(actividad.nombre_actividad);
             $form.find('#nota_maxima_actividad_cuaderno_input').val(parseFloat(actividad.nota_maxima).toFixed(2));
-            $form.find('#fecha_actividad_cuaderno_input').val(actividad.fecha_actividad ? actividad.fecha_actividad.split(' ')[0] : '');
+
+            const $fechaInput = $form.find('#fecha_actividad_cuaderno_input');
+            const $fechaGroup = $fechaInput.closest('.cpp-form-group');
+            $fechaInput.val(actividad.fecha_actividad ? actividad.fecha_actividad.split(' ')[0] : '');
+
+            if (actividad.sesion_id && actividad.sesion_id != '0') {
+                $fechaInput.prop('readonly', true);
+                $fechaGroup.addClass('cpp-readonly').attr('title', 'La fecha es gestionada automáticamente por la Programación.');
+            } else {
+                $fechaInput.prop('readonly', false);
+                $fechaGroup.removeClass('cpp-readonly').attr('title', '');
+            }
+
             $form.find('#descripcion_actividad_cuaderno_textarea').val(actividad.descripcion_actividad);
             $form.find('#clase_id_actividad_cuaderno_form').val(cpp.currentClaseIdCuaderno);
 

--- a/assets/js/cpp-modales-actividad.js
+++ b/assets/js/cpp-modales-actividad.js
@@ -35,6 +35,7 @@
             }
             
             this.resetForm(); 
+            $('#nombre_actividad_cuaderno_input').val('Nueva Actividad Evaluable');
             $('#clase_id_actividad_cuaderno_form').val(cpp.currentClaseIdCuaderno);
             $('#fecha_actividad_cuaderno_input').val(calculatedDate || ''); // Poner la fecha calculada
             if (sesionId) {
@@ -58,7 +59,7 @@
             }
 
             $('#cpp-modal-actividad-evaluable-cuaderno').fadeIn(function() {
-                $(this).find('#nombre_actividad_cuaderno_input').focus();
+                $(this).find('#nombre_actividad_cuaderno_input').select();
                 if (cpp.tutorial && cpp.tutorial.isActive && cpp.tutorial.currentStep === 8) {
                     cpp.tutorial.nextStep();
                 }

--- a/assets/js/cpp-modales-clase.js
+++ b/assets/js/cpp-modales-clase.js
@@ -501,6 +501,13 @@
                     success: (response) => {
                         if(response.success) {
                             this.refreshEvaluacionesList(claseId);
+
+                            // Notificar al programador que recargue sus datos
+                            if (typeof CppProgramadorApp !== 'undefined' && CppProgramadorApp.currentClase) {
+                                const newEvalId = response.data.evaluacion_id || null;
+                                // Forzar recarga de datos en el programador y seleccionar la nueva evaluación
+                                CppProgramadorApp.fetchData(claseId, newEvalId);
+                            }
                         } else {
                             alert('Error: ' + (response.data.message || 'No se pudo crear la evaluación.'));
                         }

--- a/assets/js/cpp-modales-clase.js
+++ b/assets/js/cpp-modales-clase.js
@@ -500,12 +500,8 @@
                     },
                     success: (response) => {
                         if(response.success) {
-                            this.refreshEvaluacionesList(claseId);
-                            // Disparar evento para notificar a otros componentes
-                            $(document).trigger('cpp:evaluacionCreada', {
-                                claseId: claseId,
-                                newEvalId: response.data.evaluacion_id
-                            });
+                            // Forzar un refresco completo de la página para asegurar la sincronización total.
+                            window.location.reload();
                         } else {
                             alert('Error: ' + (response.data.message || 'No se pudo crear la evaluación.'));
                         }

--- a/assets/js/cpp-modales-clase.js
+++ b/assets/js/cpp-modales-clase.js
@@ -501,13 +501,11 @@
                     success: (response) => {
                         if(response.success) {
                             this.refreshEvaluacionesList(claseId);
-
-                            // Notificar al programador que recargue sus datos
-                            if (typeof CppProgramadorApp !== 'undefined' && CppProgramadorApp.currentClase) {
-                                const newEvalId = response.data.evaluacion_id || null;
-                                // Forzar recarga de datos en el programador y seleccionar la nueva evaluación
-                                CppProgramadorApp.fetchData(claseId, newEvalId);
-                            }
+                            // Disparar evento para notificar a otros componentes
+                            $(document).trigger('cpp:evaluacionCreada', {
+                                claseId: claseId,
+                                newEvalId: response.data.evaluacion_id
+                            });
                         } else {
                             alert('Error: ' + (response.data.message || 'No se pudo crear la evaluación.'));
                         }

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -63,7 +63,25 @@
         $document.on('click', '#cpp-add-actividad-evaluable-btn', function() { self.addEvaluableActividad(this.dataset.sesionId); });
         $document.on('click', '.cpp-edit-evaluable-btn', function() { self.editEvaluableActividad(this.dataset.actividadId); });
         $document.on('click', '#cpp-programador-app .cpp-delete-actividad-btn', function() { self.deleteActividad(this.dataset.actividadId, this.dataset.tipo); });
-        $document.on('focusout', '#cpp-programador-app .cpp-actividad-titulo', function() { self.updateActividadTitle(this, this.dataset.actividadId); });
+        $document.on('click', '.cpp-edit-inline-actividad-btn', function(e) {
+            e.preventDefault();
+            const titleSpan = this.previousElementSibling;
+            if (titleSpan && titleSpan.classList.contains('cpp-actividad-titulo')) {
+                titleSpan.setAttribute('contenteditable', 'true');
+                titleSpan.focus();
+                const range = document.createRange();
+                range.selectNodeContents(titleSpan);
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+        });
+        $document.on('focusout', '#cpp-programador-app .cpp-actividad-titulo', function() {
+            if (this.getAttribute('contenteditable') === 'true') {
+                self.updateActividadTitle(this, this.dataset.actividadId);
+                this.setAttribute('contenteditable', 'false');
+            }
+        });
 
 
         // Horario
@@ -761,18 +779,22 @@
         const editIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>';
 
         let actionsHTML = '';
+        // The main edit button (for modal) is only for gradable activities
         if (isEvaluable) {
-            actionsHTML = `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
+            actionsHTML += `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
         }
 
-        actionsHTML += `<button class="cpp-delete-actividad-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="Eliminar">
-                            ${deleteIconSVG}
-                        </button>`;
+        // Both types get a delete button in the main actions area
+        actionsHTML += `<button class="cpp-delete-actividad-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="Eliminar">${deleteIconSVG}</button>`;
+
+        // The inline edit button is only for non-gradable activities and is placed right after the title
+        const inlineEditBtn = isEvaluable ? '' : `<button class="cpp-edit-inline-actividad-btn" data-actividad-id="${actividad.id}" title="Editar título">${editIconSVG}</button>`;
 
         return `
             <li class="cpp-actividad-item ${isEvaluable ? 'evaluable' : 'no-evaluable'}" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}">
                 <span class="cpp-actividad-handle">⠿</span>
-                <span class="cpp-actividad-titulo" contenteditable="${!isEvaluable}" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
+                <span class="cpp-actividad-titulo" contenteditable="false" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
+                ${inlineEditBtn}
                 <div class="cpp-actividad-actions">
                     ${actionsHTML}
                 </div>

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -63,25 +63,7 @@
         $document.on('click', '#cpp-add-actividad-evaluable-btn', function() { self.addEvaluableActividad(this.dataset.sesionId); });
         $document.on('click', '.cpp-edit-evaluable-btn', function() { self.editEvaluableActividad(this.dataset.actividadId); });
         $document.on('click', '#cpp-programador-app .cpp-delete-actividad-btn', function() { self.deleteActividad(this.dataset.actividadId, this.dataset.tipo); });
-        $document.on('click', '.cpp-edit-inline-actividad-btn', function(e) {
-            e.preventDefault();
-            const titleSpan = this.previousElementSibling;
-            if (titleSpan && titleSpan.classList.contains('cpp-actividad-titulo')) {
-                titleSpan.setAttribute('contenteditable', 'true');
-                titleSpan.focus();
-                const range = document.createRange();
-                range.selectNodeContents(titleSpan);
-                const sel = window.getSelection();
-                sel.removeAllRanges();
-                sel.addRange(range);
-            }
-        });
-        $document.on('focusout', '#cpp-programador-app .cpp-actividad-titulo', function() {
-            if (this.getAttribute('contenteditable') === 'true') {
-                self.updateActividadTitle(this, this.dataset.actividadId);
-                this.setAttribute('contenteditable', 'false');
-            }
-        });
+        $document.on('focusout', '#cpp-programador-app .cpp-actividad-titulo', function() { self.updateActividadTitle(this, this.dataset.actividadId); });
 
 
         // Horario
@@ -798,22 +780,18 @@
         const editIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>';
 
         let actionsHTML = '';
-        // The main edit button (for modal) is only for gradable activities
         if (isEvaluable) {
-            actionsHTML += `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
+            actionsHTML = `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
         }
 
-        // Both types get a delete button in the main actions area
-        actionsHTML += `<button class="cpp-delete-actividad-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="Eliminar">${deleteIconSVG}</button>`;
-
-        // The inline edit button is only for non-gradable activities and is placed right after the title
-        const inlineEditBtn = isEvaluable ? '' : `<button class="cpp-edit-inline-actividad-btn" data-actividad-id="${actividad.id}" title="Editar título">${editIconSVG}</button>`;
+        actionsHTML += `<button class="cpp-delete-actividad-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="Eliminar">
+                            ${deleteIconSVG}
+                        </button>`;
 
         return `
             <li class="cpp-actividad-item ${isEvaluable ? 'evaluable' : 'no-evaluable'}" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}">
                 <span class="cpp-actividad-handle">⠿</span>
-                <span class="cpp-actividad-titulo" contenteditable="false" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
-                ${inlineEditBtn}
+                <span class="cpp-actividad-titulo" contenteditable="${!isEvaluable}" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
                 <div class="cpp-actividad-actions">
                     ${actionsHTML}
                 </div>
@@ -928,6 +906,9 @@
         const actividad = this.currentSesion.actividades_programadas.find(a => a.id == actividadId);
         if (!actividad || newTitle === actividad.titulo) return;
 
+        const oldTitle = actividad.titulo;
+        actividad.titulo = newTitle;
+
         const updatedActividad = { ...actividad, titulo: newTitle };
         const data = new URLSearchParams({
             action: 'cpp_save_programador_actividad',
@@ -939,11 +920,13 @@
             .then(result => {
                 if (result.success) {
                     this.showNotification('Título guardado.');
-                    // Forzamos un refresco para asegurar la consistencia de la UI
-                    this.refreshCurrentView();
+                    if (result.data.needs_gradebook_reload) {
+                        document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
+                    }
                 } else {
                     this.showNotification('Error al guardar.', 'error');
-                    element.textContent = actividad.titulo;
+                    element.textContent = oldTitle;
+                    actividad.titulo = oldTitle;
                 }
             });
     },

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -772,7 +772,7 @@
         return `
             <li class="cpp-actividad-item ${isEvaluable ? 'evaluable' : 'no-evaluable'}" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}">
                 <span class="cpp-actividad-handle">⠿</span>
-                <span class="cpp-actividad-titulo" contenteditable="true" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
+                <span class="cpp-actividad-titulo" contenteditable="${!isEvaluable}" data-actividad-id="${actividad.id}">${actividad.titulo}</span>
                 <div class="cpp-actividad-actions">
                     ${actionsHTML}
                 </div>
@@ -897,11 +897,9 @@
             .then(res => res.json())
             .then(result => {
                 if (result.success) {
-                    actividad.titulo = newTitle;
                     this.showNotification('Título guardado.');
-                    if (result.data.needs_gradebook_reload) {
-                        document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
-                    }
+                    // Forzamos un refresco para asegurar la consistencia de la UI
+                    this.refreshCurrentView();
                 } else {
                     this.showNotification('Error al guardar.', 'error');
                     element.textContent = actividad.titulo;

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -793,8 +793,19 @@
         fetch(cppFrontendData.ajaxUrl, { method: 'POST', body: data })
             .then(res => res.json())
             .then(result => {
-                if (result.success) {
-                    this.refreshCurrentView();
+                if (result.success && result.data && result.data.actividad) {
+                    const newActividadId = result.data.actividad.id;
+                    this.refreshCurrentView(() => {
+                        const newElement = this.appElement.querySelector(`.cpp-actividad-titulo[data-actividad-id="${newActividadId}"]`);
+                        if (newElement) {
+                            newElement.focus();
+                            const range = document.createRange();
+                            const sel = window.getSelection();
+                            range.selectNodeContents(newElement);
+                            sel.removeAllRanges();
+                            sel.addRange(range);
+                        }
+                    });
                 } else {
                     this.showNotification('Error al añadir la tarea.', 'error');
                 }
@@ -898,7 +909,7 @@
             });
     },
 
-    refreshCurrentView() {
+    refreshCurrentView(callback) {
         const currentSesionId = this.currentSesion ? this.currentSesion.id : null;
         this.fetchDataFromServer().then(result => {
             if (result.success) {
@@ -911,6 +922,10 @@
                     this.currentSesion = this.sesiones.find(s => s.id == currentSesionId) || null;
                 }
                 this.render();
+                if (callback && typeof callback === 'function') {
+                    // Usamos un pequeño timeout para asegurar que el DOM se haya actualizado tras el renderizado
+                    setTimeout(callback, 50);
+                }
             } else {
                 this.showNotification('Error al refrescar los datos.', 'error');
             }

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -737,17 +737,18 @@
 
         return sesionesFiltradas.map((s, index) => {
             const fechaMostrada = s.fecha_calculada
-                ? new Date(s.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { day: '2-digit', month: 'short' })
+                ? new Date(s.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { day: 'numeric', month: 'short' })
                 : '';
+
+            const titleHTML = s.fecha_calculada
+                ? `${s.titulo}<br><small class="cpp-sesion-date">${fechaMostrada}</small>`
+                : s.titulo;
 
             return `
             <li class="cpp-sesion-list-item ${this.currentSesion && s.id == this.currentSesion.id ? 'active' : ''}" data-sesion-id="${s.id}">
                 <span class="cpp-sesion-handle">⠿</span>
-                <div class="cpp-sesion-title-wrapper">
-                    <span class="cpp-sesion-number">${index + 1}.</span>
-                    <span class="cpp-sesion-title">${s.titulo}</span>
-                    ${fechaMostrada ? `<small class="cpp-sesion-date">${fechaMostrada}</small>` : ''}
-                </div>
+                <span class="cpp-sesion-number">${index + 1}.</span>
+                <span class="cpp-sesion-title">${titleHTML}</span>
                 <div class="cpp-sesion-actions">
                     <button class="cpp-sesion-action-btn cpp-add-inline-sesion-btn" data-after-sesion-id="${s.id}" title="Añadir sesión debajo">${addIconSVG}</button>
                     <button class="cpp-sesion-action-btn cpp-delete-sesion-btn" data-sesion-id="${s.id}" title="Eliminar sesión">${deleteIconSVG}</button>
@@ -759,14 +760,15 @@
         if (!this.currentSesion) return '<p class="cpp-empty-panel">Selecciona una sesión para ver su contenido.</p>';
 
         const fechaMostrada = this.currentSesion.fecha_calculada
-            ? new Date(this.currentSesion.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+            ? new Date(this.currentSesion.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { day: 'numeric', month: 'long', year: 'numeric' })
             : '';
 
+        const headerHTML = fechaMostrada
+            ? `<h3 class="cpp-sesion-detail-title" data-field="titulo" contenteditable="true">${this.currentSesion.titulo}</h3><span class="cpp-sesion-detail-date">${fechaMostrada}</span>`
+            : `<h3 class="cpp-sesion-detail-title" data-field="titulo" contenteditable="true">${this.currentSesion.titulo}</h3>`;
+
         return `<div class="cpp-sesion-detail-container" data-sesion-id="${this.currentSesion.id}">
-                    <div class="cpp-sesion-detail-header">
-                        <h3 class="cpp-sesion-detail-title" data-field="titulo" contenteditable="true">${this.currentSesion.titulo}</h3>
-                        ${fechaMostrada ? `<span class="cpp-sesion-detail-date">${fechaMostrada}</span>` : ''}
-                    </div>
+                    ${headerHTML}
                     <div class="cpp-sesion-detail-section"><h4>Descripción</h4><div class="cpp-sesion-detail-content" data-field="descripcion" contenteditable="true">${this.currentSesion.descripcion || ''}</div></div>
                     <div class="cpp-sesion-detail-section"><h4>Objetivos</h4><div class="cpp-sesion-detail-content" data-field="objetivos" contenteditable="true">${this.currentSesion.objetivos || ''}</div></div>
                     <div class="cpp-sesion-detail-section"><h4>Recursos</h4><div class="cpp-sesion-detail-content" data-field="recursos" contenteditable="true">${this.currentSesion.recursos || ''}</div></div>

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -735,21 +735,38 @@
         const addIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4 11h-3v3h-2v-3H8v-2h3V8h2v3h3v2z"/></svg>';
         const deleteIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z"/></svg>';
 
-        return sesionesFiltradas.map((s, index) => `
+        return sesionesFiltradas.map((s, index) => {
+            const fechaMostrada = s.fecha_calculada
+                ? new Date(s.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { day: '2-digit', month: 'short' })
+                : '';
+
+            return `
             <li class="cpp-sesion-list-item ${this.currentSesion && s.id == this.currentSesion.id ? 'active' : ''}" data-sesion-id="${s.id}">
                 <span class="cpp-sesion-handle">⠿</span>
-                <span class="cpp-sesion-number">${index + 1}.</span>
-                <span class="cpp-sesion-title">${s.titulo}</span>
+                <div class="cpp-sesion-title-wrapper">
+                    <span class="cpp-sesion-number">${index + 1}.</span>
+                    <span class="cpp-sesion-title">${s.titulo}</span>
+                    ${fechaMostrada ? `<small class="cpp-sesion-date">${fechaMostrada}</small>` : ''}
+                </div>
                 <div class="cpp-sesion-actions">
                     <button class="cpp-sesion-action-btn cpp-add-inline-sesion-btn" data-after-sesion-id="${s.id}" title="Añadir sesión debajo">${addIconSVG}</button>
                     <button class="cpp-sesion-action-btn cpp-delete-sesion-btn" data-sesion-id="${s.id}" title="Eliminar sesión">${deleteIconSVG}</button>
                 </div>
-            </li>`).join('');
+            </li>`
+        }).join('');
     },
     renderProgramacionTabRightColumn() {
         if (!this.currentSesion) return '<p class="cpp-empty-panel">Selecciona una sesión para ver su contenido.</p>';
+
+        const fechaMostrada = this.currentSesion.fecha_calculada
+            ? new Date(this.currentSesion.fecha_calculada + 'T12:00:00Z').toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+            : '';
+
         return `<div class="cpp-sesion-detail-container" data-sesion-id="${this.currentSesion.id}">
-                    <h3 class="cpp-sesion-detail-title" data-field="titulo" contenteditable="true">${this.currentSesion.titulo}</h3>
+                    <div class="cpp-sesion-detail-header">
+                        <h3 class="cpp-sesion-detail-title" data-field="titulo" contenteditable="true">${this.currentSesion.titulo}</h3>
+                        ${fechaMostrada ? `<span class="cpp-sesion-detail-date">${fechaMostrada}</span>` : ''}
+                    </div>
                     <div class="cpp-sesion-detail-section"><h4>Descripción</h4><div class="cpp-sesion-detail-content" data-field="descripcion" contenteditable="true">${this.currentSesion.descripcion || ''}</div></div>
                     <div class="cpp-sesion-detail-section"><h4>Objetivos</h4><div class="cpp-sesion-detail-content" data-field="objetivos" contenteditable="true">${this.currentSesion.objetivos || ''}</div></div>
                     <div class="cpp-sesion-detail-section"><h4>Recursos</h4><div class="cpp-sesion-detail-content" data-field="recursos" contenteditable="true">${this.currentSesion.recursos || ''}</div></div>

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -83,6 +83,37 @@ function cpp_programador_get_all_data($user_id) {
         }
     }
 
+    // Calcular y adjuntar las fechas de las sesiones
+    if (!empty($clases) && !empty($sesiones)) {
+        foreach ($clases as $clase) {
+            foreach ($clase['evaluaciones'] as $evaluacion) {
+                if (!empty($evaluacion['start_date'])) {
+                    $sesiones_de_la_evaluacion = array_filter($sesiones, function($s) use ($evaluacion) {
+                        return $s->evaluacion_id == $evaluacion['id'];
+                    });
+
+                    if (!empty($sesiones_de_la_evaluacion)) {
+                        $schedule = cpp_programador_calculate_schedule_for_evaluation(
+                            array_values($sesiones_de_la_evaluacion),
+                            $evaluacion['start_date'],
+                            $config['horario'],
+                            $config['calendar_config'],
+                            $clase['id']
+                        );
+
+                        $i = 0;
+                        foreach ($sesiones_de_la_evaluacion as $sesion_obj) {
+                            if (isset($schedule[$i])) {
+                                $sesiones[$sesion_obj->id]->fecha_calculada = explode('_', $schedule[$i])[0];
+                            }
+                            $i++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     return ['clases' => $clases, 'config' => $config, 'sesiones' => array_values($sesiones), 'debug_evaluables' => $actividades_evaluables];
 }
 

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -191,12 +191,105 @@ function cpp_programador_save_sesiones_order($user_id, $clase_id, $evaluacion_id
     return true;
 }
 
+function cpp_programador_recalculate_and_update_activity_dates($evaluacion_id, $user_id) {
+    global $wpdb;
+
+    // Obtener todos los datos necesarios en una sola llamada
+    $all_data = cpp_programador_get_all_data($user_id);
+    $tabla_act_evaluables = $wpdb->prefix . 'cpp_actividades_evaluables';
+
+    $evaluacion_target = null;
+    $clase_id = null;
+
+    // Encontrar la evaluación y la clase correspondiente
+    foreach ($all_data['clases'] as $clase) {
+        foreach ($clase['evaluaciones'] as $eval) {
+            if ($eval['id'] == $evaluacion_id) {
+                $evaluacion_target = $eval;
+                $clase_id = $clase['id'];
+                break 2;
+            }
+        }
+    }
+
+    if (!$evaluacion_target || !$clase_id) {
+        return false; // No se encontró la evaluación o la clase
+    }
+
+    $start_date = $evaluacion_target['start_date'];
+    if (empty($start_date)) {
+        return true; // No hay fecha de inicio, no hay nada que recalcular
+    }
+
+    // Filtrar las sesiones que pertenecen a esta evaluación
+    $sesiones_en_evaluacion = array_filter($all_data['sesiones'], function($sesion) use ($evaluacion_id) {
+        return $sesion->evaluacion_id == $evaluacion_id;
+    });
+    $sesiones_en_evaluacion = array_values($sesiones_en_evaluacion); // Reset keys
+
+    if (empty($sesiones_en_evaluacion)) {
+        return true; // No hay sesiones, no hay nada que hacer
+    }
+
+    // Calcular el nuevo calendario de fechas para las sesiones
+    $schedule = cpp_programador_calculate_schedule_for_evaluation(
+        $sesiones_en_evaluacion,
+        $start_date,
+        $all_data['config']['horario'],
+        $all_data['config']['calendar_config'],
+        $clase_id
+    );
+
+    $wpdb->query('START TRANSACTION');
+
+    $errors = false;
+    foreach ($sesiones_en_evaluacion as $index => $sesion) {
+        if (isset($schedule[$index])) {
+            $fecha_calculada_str = explode('_', $schedule[$index])[0];
+
+            // Actualizar todas las actividades evaluables de esta sesión
+            $update_result = $wpdb->update(
+                $tabla_act_evaluables,
+                ['fecha_actividad' => $fecha_calculada_str],
+                ['sesion_id' => $sesion->id, 'user_id' => $user_id],
+                ['%s'],
+                ['%d', '%d']
+            );
+
+            if ($update_result === false) {
+                $errors = true;
+                break;
+            }
+        }
+    }
+
+    if ($errors) {
+        $wpdb->query('ROLLBACK');
+        return false;
+    }
+
+    $wpdb->query('COMMIT');
+    return true;
+}
+
+
 function cpp_programador_save_start_date($user_id, $evaluacion_id, $start_date) {
     global $wpdb;
     $tabla_evaluaciones = $wpdb->prefix . 'cpp_evaluaciones';
     $owner_check = $wpdb->get_var($wpdb->prepare("SELECT user_id FROM $tabla_evaluaciones WHERE id = %d", $evaluacion_id));
     if ($owner_check != $user_id) return false;
-    return $wpdb->update($tabla_evaluaciones, ['start_date' => $start_date], ['id' => $evaluacion_id], ['%s'], ['%d']) !== false;
+
+    $update_ok = $wpdb->update($tabla_evaluaciones, ['start_date' => $start_date], ['id' => $evaluacion_id], ['%s'], ['%d']) !== false;
+
+    if ($update_ok) {
+        // Después de guardar la nueva fecha de inicio, recalcular y actualizar las fechas de las actividades.
+        $recalculate_ok = cpp_programador_recalculate_and_update_activity_dates($evaluacion_id, $user_id);
+        // Si el recálculo falla, podríamos querer revertir el guardado de la fecha de inicio,
+        // pero por ahora, simplemente devolvemos el estado del recálculo.
+        return $recalculate_ok;
+    }
+
+    return false;
 }
 
 function cpp_programador_create_example_data($user_id) {


### PR DESCRIPTION
This commit implements a user experience improvement for creating activities.

For non-gradable activities, when a new activity is created, the title is now automatically focused and the default text is selected. This is achieved by adding a callback mechanism to the `refreshCurrentView` function in `cpp-programador.js`.

For gradable activities, the modal for creating a new activity now sets a default title and automatically selects it, allowing the user to immediately start typing a new title. This is implemented in `cpp-modales-actividad.js`.