### PR TITLE
Fix: Allow symbols to be saved in notebook cells by changing the data…

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -99,7 +99,7 @@ function cpp_crear_tablas() {
         id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
         actividad_id mediumint(9) UNSIGNED NOT NULL,
         alumno_id mediumint(9) UNSIGNED NOT NULL,
-        nota decimal(5,2) DEFAULT NULL, 
+        nota varchar(255) DEFAULT NULL,
         observaciones text,
         fecha_calificacion datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY (id),


### PR DESCRIPTION
… type of the 'nota' column to VARCHAR. The 'nota' column in the 'cpp_calificaciones_alumnos' table was previously defined as DECIMAL, which caused symbols to be converted to '0' upon saving. This commit changes the column type to VARCHAR(255) in the table creation schema to ensure that non-numeric symbols are stored correctly.