### PR TITLE
fix(programador): Correct class switching from Semana tab

### DIFF
--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -188,8 +188,17 @@
 
                 // Trigger the tab switch and class load in the main app
                 $('.cpp-main-tab-link[data-tab="programacion"]').click();
-                if (typeof cpp.loadClass === 'function') {
-                    cpp.loadClass(claseId);
+                // --- FIX ---
+                // Instead of calling a non-existent function, we find the corresponding
+                // sidebar link for the class and trigger a click on it. This reuses
+                // the existing, correct logic for switching classes.
+                const sidebarLink = $(`.cpp-sidebar-clase-item[data-clase-id="${claseId}"] a`);
+                if (sidebarLink.length) {
+                    sidebarLink.click();
+                } else {
+                    console.error(`Error de navegación: No se encontró el enlace de la clase ${claseId} en la barra lateral.`);
+                    // Opcional: mostrar un error al usuario
+                    alert('Error: No se pudo cambiar a la clase seleccionada porque no se encontró en la lista.');
                 }
             }
         }


### PR DESCRIPTION
The `navigateToSesion` function in `cpp-programador.js` was attempting to call a non-existent `cpp.loadClass` function when navigating to a session in a different class. This resulted in the class context not being updated, and the user was not navigated correctly.

This commit fixes the issue by replacing the incorrect function call with a programmatic click on the corresponding class item in the sidebar (`.cpp-sidebar-clase-item a`). This leverages the existing `seleccionarClase` logic in `cpp-sidebar.js`, ensuring that the application state is correctly updated and all components (gradebook, programmer, etc.) are properly synchronized with the new class.