### PR TITLE
Fix(export): Correctly handle array return from grade calculation

### DIFF
--- a/includes/db-queries/queries-calculos.php
+++ b/includes/db-queries/queries-calculos.php
@@ -158,8 +158,8 @@ function cpp_calcular_nota_media_final_alumno($alumno_id, $clase_id, $user_id) {
 
     // 2. Iterar sobre cada evaluación y calcular la nota final del alumno
     foreach ($evaluaciones as $evaluacion) {
-        $nota_evaluacion = cpp_calcular_nota_final_alumno($alumno_id, $clase_id, $user_id, $evaluacion['id']);
-        $suma_notas_evaluaciones += $nota_evaluacion;
+        $resultado_nota = cpp_calcular_nota_final_alumno($alumno_id, $clase_id, $user_id, $evaluacion['id']);
+        $suma_notas_evaluaciones += $resultado_nota['nota'];
     }
 
     // 3. Calcular la media de todas las evaluaciones

--- a/includes/excel-export.php
+++ b/includes/excel-export.php
@@ -159,7 +159,8 @@ function cpp_populate_sheet_with_class_data(&$sheet, $clase_info_array, $user_id
 
             // Se pasa el $evaluacion_id para que la función de cálculo sepa si debe calcular
             // la nota de una evaluación concreta o la media de todas.
-            $nota_final_0_100 = cpp_calcular_nota_final_alumno($alumno['id'], $clase_id, $user_id, $evaluacion_id);
+            $resultado_nota_final = cpp_calcular_nota_final_alumno($alumno['id'], $clase_id, $user_id, $evaluacion_id);
+            $nota_final_0_100 = $resultado_nota_final['nota'];
             $nota_final_reescalada = ($nota_final_0_100 / 100) * $base_nota_final_clase;
             
             $sheet->setCellValue($col_final_nota_char . $current_row_excel, $nota_final_reescalada);


### PR DESCRIPTION
Resolves a fatal TypeError that occurred during the Excel export process. The `cpp_calcular_nota_final_alumno` function returns an associative array containing the grade and other metadata, not a raw numeric value.

The code in `includes/excel-export.php` was attempting to use this array in an arithmetic operation, causing the error. This commit corrects the logic to access the 'nota' key from the returned array before performing calculations.

A similar latent bug was fixed in `includes/db-queries/queries-calculos.php` where the `cpp_calcular_nota_media_final_alumno` function also made an incorrect assumption about the return type.