### PR TITLE
Add Rich Text Student Notes Editor to Student Profile

### DIFF
--- a/assets/css/cpp-alumnos.css
+++ b/assets/css/cpp-alumnos.css
@@ -599,6 +599,85 @@
     border-bottom: none;
 }
 
+/* --- Editor de Notas --- */
+.cpp-notas-editor-container {
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    overflow: hidden;
+    background-color: #fff;
+    margin-bottom: 15px;
+}
+
+.cpp-editor-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 8px;
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.cpp-editor-toolbar button {
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 4px;
+    cursor: pointer;
+    color: #495057;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.cpp-editor-toolbar button:hover {
+    background-color: #e9ecef;
+    border-color: #ced4da;
+}
+
+.cpp-editor-toolbar .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.cpp-editor-color-picker {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 4px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.cpp-editor-color-picker:hover {
+    background-color: #e9ecef;
+}
+
+.cpp-editor-color-picker input[type="color"] {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+    cursor: pointer;
+}
+
+.cpp-notas-editor-content {
+    min-height: 200px;
+    padding: 15px;
+    font-size: 15px;
+    line-height: 1.5;
+    outline: none;
+    color: #212529;
+}
+
+.cpp-notas-editor-content:focus {
+    background-color: #fff;
+}
+
 .cpp-asistencia-items-inner-list {
     list-style: none;
     margin: 0;

--- a/assets/js/cpp-alumnos.js
+++ b/assets/js/cpp-alumnos.js
@@ -59,6 +59,14 @@
             $document.on('click', '#cpp-alumno-foto-editable', this.handleChangeFoto.bind(this));
             $document.on('change', '#cpp-alumno-foto-input', this.handleUploadFoto.bind(this));
             $document.on('click', '#cpp-regenerate-avatar-btn', this.handleRegenerateAvatar.bind(this));
+            $document.on('click', '#cpp-save-notas-alumno-btn', this.handleSaveNotas.bind(this));
+            $document.on('click', '.cpp-editor-toolbar button[data-command]', this.handleEditorAction.bind(this));
+            $document.on('input', '.cpp-editor-forecolor', function() {
+                document.execCommand('foreColor', false, $(this).val());
+            });
+            $document.on('input', '.cpp-editor-hilitecolor', function() {
+                document.execCommand('hiliteColor', false, $(this).val());
+            });
 
             // Handlers para el formulario de nuevo alumno
             $document.on('click', '#cpp-new-alumno-foto-preview', function() {
@@ -490,6 +498,36 @@
                     </div>`;
             }
 
+            let notasHtml = '';
+            if (!isNew) {
+                notasHtml = `
+                    <div class="cpp-ficha-section">
+                        <h3>Notas sobre el alumno</h3>
+                        <div class="cpp-notas-editor-container">
+                            <div class="cpp-editor-toolbar">
+                                <button type="button" data-command="bold" title="Negrita"><span class="dashicons dashicons-editor-bold"></span></button>
+                                <button type="button" data-command="underline" title="Subrayado"><span class="dashicons dashicons-editor-underline"></span></button>
+                                <div class="cpp-editor-color-picker" title="Color de fuente">
+                                    <span class="dashicons dashicons-editor-textcolor"></span>
+                                    <input type="color" class="cpp-editor-forecolor" value="#000000">
+                                </div>
+                                <div class="cpp-editor-color-picker" title="Color de fondo">
+                                    <span class="dashicons dashicons-admin-appearance"></span>
+                                    <input type="color" class="cpp-editor-hilitecolor" value="#ffffff">
+                                </div>
+                            </div>
+                            <div id="cpp-alumno-notas-editor" contenteditable="true" class="cpp-notas-editor-content">
+                                ${alumno.notas || ''}
+                            </div>
+                        </div>
+                        <div class="cpp-form-actions" style="margin-top: 10px;">
+                            <button type="button" id="cpp-save-notas-alumno-btn" class="cpp-btn cpp-btn-primary" data-alumno-id="${alumno.id}">
+                                <span class="dashicons dashicons-saved"></span> Guardar Notas
+                            </button>
+                        </div>
+                    </div>`;
+            }
+
             const finalHtml = `
                 <div class="cpp-alumno-ficha-card">
                     ${personalDataHtml}
@@ -497,6 +535,7 @@
                     ${visualDataHtml}
                     ${calificacionesHtml}
                     ${asistenciaGlobalHtml}
+                    ${notasHtml}
                     ${footerHtml}
                 </div>`;
 
@@ -1018,6 +1057,45 @@
                         $('#cpp-alumno-foto-url-input').val(newFotoUrl);
 
                         $(document).trigger('cpp:forceGradebookReload');
+                    } else {
+                        cpp.utils.showToast(response.data.message, 'error');
+                    }
+                },
+                error: () => {
+                    cpp.utils.hideSpinner();
+                    cpp.utils.showToast('Error de conexión.', 'error');
+                }
+            });
+        },
+
+        handleEditorAction: function(e) {
+            const $btn = $(e.currentTarget);
+            const command = $btn.data('command');
+
+            if (command) {
+                document.execCommand(command, false, null);
+            }
+        },
+
+        handleSaveNotas: function(e) {
+            const alumnoId = $(e.currentTarget).data('alumno-id');
+            const notas = $('#cpp-alumno-notas-editor').html();
+
+            cpp.utils.showSpinner();
+            $.ajax({
+                url: cppFrontendData.ajaxUrl,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'cpp_save_alumno_notas',
+                    nonce: cppFrontendData.nonce,
+                    alumno_id: alumnoId,
+                    notas: notas
+                },
+                success: (response) => {
+                    cpp.utils.hideSpinner();
+                    if (response.success) {
+                        cpp.utils.showToast(response.data.message);
                     } else {
                         cpp.utils.showToast(response.data.message, 'error');
                     }

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -10,7 +10,7 @@ Author: Javier Vegas Serrano
 defined('ABSPATH') or die('Acceso no permitido');
 
 // --- VERSIÓN ACTUALIZADA PARA LA NUEVA MIGRACIÓN ---
-define('CPP_VERSION', '2.8.3');
+define('CPP_VERSION', '2.8.4');
 
 // Constantes
 define('CPP_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -408,6 +408,17 @@ function cpp_migrate_alumnos_to_many_to_many_v2_3_0_final() {
 
 function cpp_run_migrations() {
     $current_version = get_option('cpp_version', '1.0');
+
+    if (version_compare($current_version, '2.8.4', '<')) {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'cpp_alumnos';
+        $column_name = 'notas';
+
+        $column_exists = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM `$table_name` LIKE %s", $column_name));
+        if (!$column_exists) {
+            $wpdb->query("ALTER TABLE `$table_name` ADD `$column_name` LONGTEXT AFTER `foto` ");
+        }
+    }
 
     if (version_compare($current_version, '1.6', '<')) {
         cpp_migrate_add_passing_grade_v1_6();

--- a/includes/ajax-handlers/ajax-alumnos.php
+++ b/includes/ajax-handlers/ajax-alumnos.php
@@ -320,6 +320,37 @@ function cpp_ajax_delete_alumno_globally() {
     wp_send_json_success(['message' => 'Alumno eliminado permanentemente.']);
 }
 
+add_action('wp_ajax_cpp_save_alumno_notas', 'cpp_ajax_save_alumno_notas');
+function cpp_ajax_save_alumno_notas() {
+    check_ajax_referer('cpp_frontend_nonce', 'nonce');
+    $user_id = get_current_user_id();
+    $alumno_id = isset($_POST['alumno_id']) ? intval($_POST['alumno_id']) : 0;
+    $notas = isset($_POST['notas']) ? wp_kses_post($_POST['notas']) : '';
+
+    if (empty($alumno_id)) {
+        wp_send_json_error(['message' => 'ID de alumno no válido.']);
+    }
+
+    if (!cpp_es_propietario_alumno($user_id, $alumno_id)) {
+        wp_send_json_error(['message' => 'Permiso denegado.']);
+    }
+
+    global $wpdb;
+    $result = $wpdb->update(
+        $wpdb->prefix . 'cpp_alumnos',
+        ['notas' => $notas],
+        ['id' => $alumno_id, 'user_id' => $user_id],
+        ['%s'],
+        ['%d', '%d']
+    );
+
+    if ($result === false) {
+        wp_send_json_error(['message' => 'Error al guardar las notas.']);
+    }
+
+    wp_send_json_success(['message' => 'Notas guardadas correctamente.']);
+}
+
 // --- LÓGICA PARA LA PANTALLA DE CONFIGURACIÓN DE CLASE ---
 
 add_action('wp_ajax_cpp_get_alumnos_for_clase_config', 'cpp_ajax_get_alumnos_for_clase_config');

--- a/includes/db.php
+++ b/includes/db.php
@@ -69,6 +69,7 @@ function cpp_crear_tablas() {
         nombre varchar(50) NOT NULL,
         apellidos varchar(100) NOT NULL,
         foto varchar(255),
+        notas longtext,
         fecha_creacion datetime DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (id),
         KEY user_id (user_id)


### PR DESCRIPTION
This change introduces a "Notas sobre el alumno" (Student Notes) section in the global student profile. 

Key features:
1. **Persistent Storage**: A new `notas` column in the `cpp_alumnos` table stores the notes globally for each student.
2. **Rich Text Editor**: A lightweight, Gmail-style editor was implemented using `contenteditable`. It includes a toolbar for basic formatting: Bold, Underline, Font Color, and Background Color.
3. **Manual Save**: Users can save their notes by clicking the "Guardar Notas" button, providing explicit control over data persistence.
4. **Backend Security**: Notes are sanitized using `wp_kses_post` on the server-side to ensure security while allowing basic HTML formatting.
5. **UI Integration**: The editor is placed at the bottom of the student profile, following the attendance section, to maintain a clean layout.
6. **Versioning**: The plugin version was bumped to 2.8.4 to trigger the necessary database migrations.

---
*PR created automatically by Jules for task [14574670551961290920](https://jules.google.com/task/14574670551961290920) started by @vegasmadrid*