### PR TITLE
Synchronize session dates with gradebook activities

### DIFF
--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -3,14 +3,14 @@
 /*
 Plugin Name: Cuaderno de profe
 Description: Gestión de clases y alumnos completamente desde el frontend.
-Version: 1.9
+Version: 2.8.6
 Author: Javier Vegas Serrano
 */
 
 defined('ABSPATH') or die('Acceso no permitido');
 
 // --- VERSIÓN ACTUALIZADA PARA LA NUEVA MIGRACIÓN ---
-define('CPP_VERSION', '2.8.5');
+define('CPP_VERSION', '2.8.6');
 
 // Constantes
 define('CPP_PLUGIN_DIR', plugin_dir_path(__FILE__));

--- a/includes/db-queries/queries-actividades-calificaciones.php
+++ b/includes/db-queries/queries-actividades-calificaciones.php
@@ -22,7 +22,7 @@ function cpp_hidratar_fechas_de_actividades($actividades, $clase_id, $evaluacion
 
     $actividades_a_hidratar = [];
     foreach ($actividades as $actividad) {
-        if (empty($actividad['fecha_actividad']) && !empty($actividad['sesion_id'])) {
+        if (!empty($actividad['sesion_id'])) {
             $actividades_a_hidratar[$actividad['id']] = $actividad['sesion_id'];
         }
     }

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -137,6 +137,9 @@ function cpp_ajax_delete_programador_sesion() {
     $sesion_info = $wpdb->get_row($wpdb->prepare("SELECT clase_id, evaluacion_id FROM $tabla_sesiones WHERE id = %d AND user_id = %d", $sesion_id, $user_id));
 
     if (cpp_programador_delete_sesion($sesion_id, $user_id, $delete_activities)) {
+        if ($sesion_info) {
+             cpp_programador_recalculate_and_update_activity_dates($sesion_info->evaluacion_id, $user_id);
+        }
         wp_send_json_success(['message' => 'Sesión eliminada.', 'needs_gradebook_reload' => true]);
     } else {
         wp_send_json_error(['message' => 'Error al eliminar la sesión.']);
@@ -153,6 +156,8 @@ function cpp_ajax_save_sesiones_order() {
     $orden = isset($_POST['orden']) ? json_decode(stripslashes($_POST['orden'])) : [];
     if (empty($clase_id) || empty($evaluacion_id) || !is_array($orden)) { wp_send_json_error(['message' => 'Faltan datos para reordenar.']); return; }
     if (cpp_programador_save_sesiones_order($user_id, $clase_id, $evaluacion_id, $orden)) {
+        // Recalcular fechas de actividades en el cuaderno tras reordenar
+        cpp_programador_recalculate_and_update_activity_dates($evaluacion_id, $user_id);
         wp_send_json_success(['message' => 'Orden guardado.', 'needs_gradebook_reload' => true]);
     } else {
         wp_send_json_error(['message' => 'Error al guardar el orden.']);
@@ -224,6 +229,9 @@ function cpp_ajax_add_inline_sesion() {
     $result = cpp_programador_add_sesion_inline($sesion_data, $after_sesion_id, $user_id);
 
     if ($result) {
+        // Recalcular fechas tras añadir sesión inline
+        cpp_programador_recalculate_and_update_activity_dates($sesion_data['evaluacion_id'], $user_id);
+
         // --- FIX: Devolver la sesión completa en lugar de recargar todo ---
         $sesion_completa = cpp_programador_get_sesion_by_id($result, $user_id);
 
@@ -517,6 +525,11 @@ function cpp_ajax_delete_multiple_sesiones() {
     $result = cpp_programador_delete_multiple_sesiones($session_ids, $user_id, $delete_activities);
 
     if ($result) {
+        if (!empty($affected_evaluations)) {
+            foreach ($affected_evaluations as $eval) {
+                cpp_programador_recalculate_and_update_activity_dates($eval->evaluacion_id, $user_id);
+            }
+        }
         wp_send_json_success(['message' => 'Sesiones eliminadas correctamente.', 'needs_gradebook_reload' => true]);
     } else {
         wp_send_json_error(['message' => 'Ocurrió un error al eliminar una o más de las sesiones seleccionadas.']);
@@ -576,6 +589,9 @@ function cpp_ajax_toggle_sesion_fijada() {
     $result = cpp_programador_toggle_sesion_fijada($session_ids, $fijar, $user_id);
 
     if ($result) {
+        // Recalcular fechas persistidas
+        cpp_programador_recalculate_and_update_activity_dates($sesion_info->evaluacion_id, $user_id);
+
         // Devolver las nuevas fechas para actualizar la UI
         $fechas_actualizadas = cpp_programador_get_fechas_for_evaluacion($user_id, $sesion_info->clase_id, $sesion_info->evaluacion_id);
 

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -507,6 +507,13 @@ function cpp_programador_recalculate_and_update_activity_dates($evaluacion_id, $
 
     $wpdb->query('START TRANSACTION');
 
+    // Resetear todas las fechas de actividades de esta evaluación que dependen de sesiones
+    // Esto asegura que si una sesión ya no tiene fecha calculada (ej: se salió del rango), la actividad no mantenga una fecha vieja.
+    $wpdb->query($wpdb->prepare(
+        "UPDATE $tabla_act_evaluables SET fecha_actividad = NULL WHERE evaluacion_id = %d AND user_id = %d AND sesion_id IS NOT NULL",
+        $evaluacion_id, $user_id
+    ));
+
     $errors = false;
     foreach ($fechas_calculadas as $sesion_id => $data) {
         $fecha_calculada_str = $data['fecha'];


### PR DESCRIPTION
This change fixes the issue where moving sessions in the Programming tab did not correctly update the dates in the Gradebook.

1. **Frontend-Backend Sync**: The `cpp_hidratar_fechas_de_actividades` function now treats the Programming module as the absolute source of truth for any activity linked to a session, ensuring that the Gradebook UI always reflects the latest calculated dates upon load/reload.

2. **Database Persistence**: Multiple AJAX handlers in `includes/programador/ajax-programador.php` (reorder, delete, add inline, toggle fixed) now trigger a background recalculation and persistence of activity dates to ensure that even if the page isn't reloaded, the database remains consistent.

3. **Stale Data Prevention**: The recalculation logic now resets activity dates to NULL before applying new ones, preventing old dates from sticking around if a session's date can no longer be calculated.

4. **Cache Busting**: Incremented `CPP_VERSION` to 2.8.6.

---
*PR created automatically by Jules for task [9211176290774544938](https://jules.google.com/task/9211176290774544938) started by @vegasmadrid*