### PR TITLE
Convertible Evaluable Activities

### DIFF
--- a/assets/js/cpp-actividades.js
+++ b/assets/js/cpp-actividades.js
@@ -202,7 +202,7 @@
                 if (!confirm(`¿Estás seguro de que quieres convertir la actividad "${nombre}" en una tarea no evaluable?\n\n¡Se borrarán todas las notas registradas en el cuaderno para esta actividad y no se puede deshacer!`)) {
                     return;
                 }
-                this.executeToggleEvaluable(actividadId, 0, null, $row);
+                this.executeToggleEvaluable(actividadId, 0, null, $row, tipo);
             } else {
                 // Convertir a evaluable. Necesitamos el criterio si la evaluación es ponderada.
                 const evaluacionId = $row.data('evaluacion-id');
@@ -229,7 +229,7 @@
                 if (criterios.length === 0) {
                      // Si no hay criterios globales, puede que no se hayan cargado.
                      // En este caso el backend usará el primero que encuentre.
-                     this.executeToggleEvaluable(actividadId, 1, null, $row);
+                     this.executeToggleEvaluable(actividadId, 1, null, $row, tipo);
                      return;
                 }
 
@@ -249,11 +249,11 @@
                     return;
                 }
 
-                this.executeToggleEvaluable(actividadId, 1, criterios[index].id, $row);
+                this.executeToggleEvaluable(actividadId, 1, criterios[index].id, $row, tipo);
             }
         },
 
-        executeToggleEvaluable: function(actividadId, esEvaluable, criterioId, $row) {
+        executeToggleEvaluable: function(actividadId, esEvaluable, criterioId, $row, tipo) {
             const self = this;
             if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
 
@@ -266,7 +266,8 @@
                     nonce: cppFrontendData.nonce,
                     actividad_id: actividadId,
                     es_evaluable: esEvaluable,
-                    criterio_id: criterioId || ''
+                    criterio_id: criterioId || '',
+                    tipo: tipo || ''
                 },
                 success: function(response) {
                     if (response.success) {

--- a/assets/js/cpp-actividades.js
+++ b/assets/js/cpp-actividades.js
@@ -50,7 +50,7 @@
                         $container.html(response.data.html);
 
                         // Sincronizar el dropdown de criterios con los contadores actualizados
-                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica);
+                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica, response.data.num_no_evaluables);
 
                         // Aplicar tooltips o lógica adicional si fuera necesario para los badges de "No aplica"
 
@@ -74,7 +74,7 @@
             });
         },
 
-        updateCriterionDropdownLabels: function(criterios, numSinCriterio, numNoAplica) {
+        updateCriterionDropdownLabels: function(criterios, numSinCriterio, numNoAplica, numNoEvaluables) {
             if (!criterios) return;
 
             const $filterCriterio = $('#cpp-actividades-filter-criterio');
@@ -92,6 +92,10 @@
             const noAplicaCount = numNoAplica || 0;
             html += `<option value="-2" ${currentValue == -2 ? 'selected' : ''}>No aplica (${noAplicaCount})</option>`;
 
+            // Opción Tareas no evaluables
+            const noEvalCount = numNoEvaluables || 0;
+            html += `<option value="-3" ${currentValue == -3 ? 'selected' : ''}>Tareas no evaluables (${noEvalCount})</option>`;
+
             criterios.forEach(crit => {
                 html += `<option value="${crit.id}" ${crit.id == currentValue ? 'selected' : ''}>${crit.nombre} (${crit.num_actividades})</option>`;
             });
@@ -106,6 +110,7 @@
             const $row = $input.closest('tr');
             const actividadId = $row.data('actividad-id');
             const evaluacionId = $row.data('evaluacion-id');
+            const tipo = $row.data('tipo');
             const field = $input.data('field');
             const value = $input.val();
             const originalValue = $input.data('original-value');
@@ -123,6 +128,7 @@
                     nonce: cppFrontendData.nonce,
                     actividad_id: actividadId,
                     evaluacion_id: evaluacionId,
+                    tipo: tipo,
                     field: field,
                     value: value
                 },
@@ -137,7 +143,7 @@
                         }
 
                         // Actualizar contadores del dropdown con la info que viene en la respuesta
-                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica);
+                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica, response.data.num_no_evaluables);
 
                         // Si cambiamos el nombre, categoría o nota máxima, el cuaderno debe saberlo
                         if (['nombre_actividad', 'categoria_id', 'criterio_id', 'nota_maxima'].includes(field)) {
@@ -184,13 +190,122 @@
             });
         },
 
+        handleToggleEvaluable: function(buttonElement) {
+            const self = this;
+            const $row = $(buttonElement).closest('tr');
+            const actividadId = $row.data('actividad-id');
+            const tipo = $row.data('tipo');
+            const nombre = $row.find('[data-field="nombre_actividad"]').val() || 'Actividad';
+            const isEvaluable = tipo === 'evaluable';
+
+            if (isEvaluable) {
+                if (!confirm(`¿Estás seguro de que quieres convertir la actividad "${nombre}" en una tarea no evaluable?\n\n¡Se borrarán todas las notas registradas en el cuaderno para esta actividad y no se puede deshacer!`)) {
+                    return;
+                }
+                this.executeToggleEvaluable(actividadId, 0, null, $row);
+            } else {
+                // Convertir a evaluable. Necesitamos el criterio si la evaluación es ponderada.
+                const evaluacionId = $row.data('evaluacion-id');
+                const $claseSelect = $('#cpp-actividades-filter-clase');
+                const claseId = $row.data('clase-id') || $claseSelect.val();
+
+                // Intentamos obtener info de la evaluación desde el objeto CppProgramadorApp si está disponible,
+                // o hacemos una pequeña petición para saber si es ponderada y qué criterios tiene.
+                // Para simplificar y mantener consistencia con el programador, usaremos un prompt si detectamos que es necesario.
+
+                // NOTA: En la vista de Actividades, el objeto 'actividades' devuelto por el servidor ya tiene 'calculo_nota'.
+                // Pero no tenemos la lista de criterios de esa evaluación específica fácilmente a mano sin otra petición.
+                // Vamos a usar la lista global de criterios que ya tenemos en el dropdown de filtros.
+
+                const $filterCriterio = $('#cpp-actividades-filter-criterio');
+                const criterios = [];
+                $filterCriterio.find('option').each(function() {
+                    const val = parseInt($(this).val());
+                    if (val > 0) {
+                        criterios.push({ id: val, nombre: $(this).text().split(' (')[0] });
+                    }
+                });
+
+                if (criterios.length === 0) {
+                     // Si no hay criterios globales, puede que no se hayan cargado.
+                     // En este caso el backend usará el primero que encuentre.
+                     this.executeToggleEvaluable(actividadId, 1, null, $row);
+                     return;
+                }
+
+                let message = `Convirtiendo "${nombre}" a evaluable.\nSelecciona un criterio:\n\n`;
+                criterios.forEach((crit, index) => {
+                    message += `${index + 1}. ${crit.nombre}\n`;
+                });
+
+                const choice = prompt(message, "1");
+                if (choice === null) return;
+
+                const index = parseInt(choice) - 1;
+                if (isNaN(index) || !criterios[index]) {
+                    if (cpp.utils && typeof cpp.utils.showToast === 'function') {
+                        cpp.utils.showToast('Opción no válida.', 'error');
+                    }
+                    return;
+                }
+
+                this.executeToggleEvaluable(actividadId, 1, criterios[index].id, $row);
+            }
+        },
+
+        executeToggleEvaluable: function(actividadId, esEvaluable, criterioId, $row) {
+            const self = this;
+            if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
+
+            $.ajax({
+                url: cppFrontendData.ajaxUrl,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'cpp_toggle_actividad_evaluable',
+                    nonce: cppFrontendData.nonce,
+                    actividad_id: actividadId,
+                    es_evaluable: esEvaluable,
+                    criterio_id: criterioId || ''
+                },
+                success: function(response) {
+                    if (response.success) {
+                        if (cpp.utils && typeof cpp.utils.showToast === 'function') {
+                            cpp.utils.showToast(esEvaluable ? 'Convertido a Actividad Evaluable' : 'Convertido a Tarea', 'success');
+                        }
+                        // Recargar la vista para reflejar los cambios
+                        self.render();
+                        $(document).trigger('cpp:forceGradebookReload');
+                    } else {
+                        if (cpp.utils && typeof cpp.utils.showToast === 'function') {
+                            cpp.utils.showToast('Error: ' + response.data.message, 'error');
+                        }
+                    }
+                },
+                error: function() {
+                    if (cpp.utils && typeof cpp.utils.showToast === 'function') {
+                        cpp.utils.showToast('Error de conexión.', 'error');
+                    }
+                },
+                complete: function() {
+                    if (cpp.utils && typeof cpp.utils.hideSpinner === 'function') cpp.utils.hideSpinner();
+                }
+            });
+        },
+
         handleDelete: function(buttonElement) {
             const self = this;
             const $row = $(buttonElement).closest('tr');
             const actividadId = $row.data('actividad-id');
+            const tipo = $row.data('tipo');
             const nombre = $row.find('[data-field="nombre_actividad"]').val();
 
-            if (!confirm(`¿Estás seguro de que quieres eliminar la actividad "${nombre}"?\n\n¡Esta acción borrará todas las notas de los alumnos para esta actividad y no se puede deshacer!`)) {
+            const isEvaluable = tipo === 'evaluable';
+            const confirmMsg = isEvaluable
+                ? `¿Estás seguro de que quieres eliminar la actividad "${nombre}"?\n\n¡Esta acción borrará todas las notas de los alumnos para esta actividad y no se puede deshacer!`
+                : `¿Estás seguro de que quieres eliminar la tarea "${nombre}"?`;
+
+            if (!confirm(confirmMsg)) {
                 return;
             }
 
@@ -201,7 +316,8 @@
                 data: {
                     action: 'cpp_eliminar_actividad',
                     nonce: cppFrontendData.nonce,
-                    actividad_id: actividadId
+                    actividad_id: actividadId,
+                    tipo: tipo
                 },
                 success: function(response) {
                     if (response.success) {
@@ -212,7 +328,7 @@
                         }
 
                         // Actualizar contadores del dropdown
-                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica);
+                        self.updateCriterionDropdownLabels(response.data.criterios, response.data.num_sin_criterio, response.data.num_no_aplica, response.data.num_no_evaluables);
 
                         $(document).trigger('cpp:forceGradebookReload');
                         if (typeof CppProgramadorApp !== 'undefined' && CppProgramadorApp.currentClase) {
@@ -308,6 +424,10 @@
 
             $document.on('click', '.cpp-btn-delete-actividad', function() {
                 self.handleDelete(this);
+            });
+
+            $document.on('click', '.cpp-btn-toggle-actividad', function() {
+                self.handleToggleEvaluable(this);
             });
 
             $document.on('change', 'select[data-field="categoria_id"], select[data-field="criterio_id"]', function() {

--- a/assets/js/cpp-modales-actividad.js
+++ b/assets/js/cpp-modales-actividad.js
@@ -23,7 +23,7 @@
                 // Mostramos todos los campos por defecto al resetear
                 $form.find('.cpp-form-group').show();
                 $form.find('#cpp-eliminar-actividad-btn-modal').hide();
-                $form.find('#cpp-convertir-tarea-btn-modal').hide();
+                $form.find('#cpp-modal-actividad-conversion-area').hide();
                 // Ocultar el display de fecha y mostrar el input por defecto
                 $form.find('#cpp-fecha-actividad-display').hide();
                 $form.find('#fecha_actividad_cuaderno_input').show();
@@ -162,9 +162,9 @@
             $modal.find('#cpp-submit-actividad-btn-cuaderno-form').html('<span class="dashicons dashicons-edit"></span> Actualizar Actividad');
             $form.find('#cpp-eliminar-actividad-btn-modal').show();
             if (sesionId && sesionId !== 'null' && sesionId !== '0' && sesionId !== 0) {
-                $form.find('#cpp-convertir-tarea-btn-modal').show();
+                $form.find('#cpp-modal-actividad-conversion-area').show();
             } else {
-                $form.find('#cpp-convertir-tarea-btn-modal').hide();
+                $form.find('#cpp-modal-actividad-conversion-area').hide();
             }
             $modal.fadeIn();
             $form.find('#nombre_actividad_cuaderno_input').focus();
@@ -322,9 +322,9 @@
             $modal.find('#cpp-submit-actividad-btn-cuaderno-form').html('<span class="dashicons dashicons-edit"></span> Actualizar Actividad');
             $form.find('#cpp-eliminar-actividad-btn-modal').show();
             if (actividad.sesion_id && actividad.sesion_id !== '0' && actividad.sesion_id !== 'null' && actividad.sesion_id !== 0) {
-                $form.find('#cpp-convertir-tarea-btn-modal').show();
+                $form.find('#cpp-modal-actividad-conversion-area').show();
             } else {
-                $form.find('#cpp-convertir-tarea-btn-modal').hide();
+                $form.find('#cpp-modal-actividad-conversion-area').hide();
             }
             $modal.fadeIn();
             $form.find('#nombre_actividad_cuaderno_input').focus();
@@ -421,6 +421,7 @@
             $modal.find('#cpp-modal-actividad-titulo-cuaderno').text('Configurar Actividad Evaluable');
             $modal.find('#cpp-submit-actividad-btn-cuaderno-form').html('<span class="dashicons dashicons-saved"></span> Guardar y Hacer Evaluable');
             $modal.find('#cpp-eliminar-actividad-btn-modal').hide(); // Ocultar botón de eliminar en este contexto
+            $modal.find('#cpp-modal-actividad-conversion-area').hide();
 
             // Lógica de categorías
             if (evaluacion && evaluacion.calculo_nota === 'ponderada' && evaluacion.criterios && evaluacion.criterios.length > 0) {

--- a/assets/js/cpp-modales-actividad.js
+++ b/assets/js/cpp-modales-actividad.js
@@ -23,6 +23,7 @@
                 // Mostramos todos los campos por defecto al resetear
                 $form.find('.cpp-form-group').show();
                 $form.find('#cpp-eliminar-actividad-btn-modal').hide();
+                $form.find('#cpp-convertir-tarea-btn-modal').hide();
                 // Ocultar el display de fecha y mostrar el input por defecto
                 $form.find('#cpp-fecha-actividad-display').hide();
                 $form.find('#fecha_actividad_cuaderno_input').show();
@@ -160,6 +161,11 @@
             $modal.find('#cpp-modal-actividad-titulo-cuaderno').text('Editar Actividad Evaluable');
             $modal.find('#cpp-submit-actividad-btn-cuaderno-form').html('<span class="dashicons dashicons-edit"></span> Actualizar Actividad');
             $form.find('#cpp-eliminar-actividad-btn-modal').show();
+            if (sesionId && sesionId !== 'null' && sesionId !== '0' && sesionId !== 0) {
+                $form.find('#cpp-convertir-tarea-btn-modal').show();
+            } else {
+                $form.find('#cpp-convertir-tarea-btn-modal').hide();
+            }
             $modal.fadeIn();
             $form.find('#nombre_actividad_cuaderno_input').focus();
         },
@@ -315,6 +321,11 @@
             $modal.find('#cpp-modal-actividad-titulo-cuaderno').text('Editar Actividad Evaluable');
             $modal.find('#cpp-submit-actividad-btn-cuaderno-form').html('<span class="dashicons dashicons-edit"></span> Actualizar Actividad');
             $form.find('#cpp-eliminar-actividad-btn-modal').show();
+            if (actividad.sesion_id && actividad.sesion_id !== '0' && actividad.sesion_id !== 'null' && actividad.sesion_id !== 0) {
+                $form.find('#cpp-convertir-tarea-btn-modal').show();
+            } else {
+                $form.find('#cpp-convertir-tarea-btn-modal').hide();
+            }
             $modal.fadeIn();
             $form.find('#nombre_actividad_cuaderno_input').focus();
         },
@@ -442,6 +453,68 @@
             $modal.on('click', '#cpp-eliminar-actividad-btn-modal', (e) => {
                 e.preventDefault();
                 this.eliminar();
+            });
+
+            $modal.on('click', '#cpp-convertir-tarea-btn-modal', (e) => {
+                e.preventDefault();
+                this.convertirATarea();
+            });
+        },
+
+        convertirATarea: function() {
+            const $form = $('#cpp-form-actividad-evaluable-cuaderno');
+            const actividadId = $form.find('#actividad_id_editar_cuaderno').val();
+            const nombre = $form.find('#nombre_actividad_cuaderno_input').val();
+
+            if (!confirm(`¿Estás seguro de que quieres convertir "${nombre}" en una tarea no evaluable?\n\n¡Se borrarán todas las notas registradas en el cuaderno para esta actividad y no se puede deshacer!`)) {
+                return;
+            }
+
+            const $btn = $('#cpp-convertir-tarea-btn-modal');
+            const originalHtml = $btn.html();
+            $btn.prop('disabled', true).html('<span class="dashicons dashicons-update dashicons-spin"></span>');
+
+            $.ajax({
+                url: cppFrontendData.ajaxUrl,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'cpp_toggle_actividad_evaluable',
+                    nonce: cppFrontendData.nonce,
+                    actividad_id: actividadId,
+                    es_evaluable: 0,
+                    tipo: 'evaluable'
+                },
+                success: function(response) {
+                    if (response.success) {
+                        $('#cpp-modal-actividad-evaluable-cuaderno').fadeOut();
+
+                        // Recargar cuaderno
+                        document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
+
+                        // Recargar Programador si existe
+                        if (typeof CppProgramadorApp !== 'undefined' && CppProgramadorApp.currentClase) {
+                            CppProgramadorApp.fetchData(CppProgramadorApp.currentClase.id);
+                        }
+
+                        // Recargar vista global de actividades si existe
+                        if (cpp.actividades && typeof cpp.actividades.render === 'function') {
+                            cpp.actividades.render();
+                        }
+
+                        if (cpp.utils && typeof cpp.utils.showToast === 'function') {
+                            cpp.utils.showToast('Actividad convertida en tarea.', 'success');
+                        }
+                    } else {
+                        alert('Error al convertir: ' + (response.data && response.data.message ? response.data.message : 'Error desconocido.'));
+                    }
+                },
+                error: function() {
+                    alert('Error de conexión al intentar convertir la actividad.');
+                },
+                complete: function() {
+                    $btn.prop('disabled', false).html(originalHtml);
+                }
             });
         }
     };

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -2291,11 +2291,12 @@
         const isEvaluable = actividad.tipo === 'evaluable';
         const deleteIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z"/></svg>';
         const editIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>';
-        const toggleEvaluableIconSVG = isEvaluable
-            ? '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="#FFD700"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>'
-            : '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></svg>';
 
-        let actionsHTML = `<button class="cpp-toggle-evaluable-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="${isEvaluable ? 'Convertir en Tarea (No Evaluable)' : 'Convertir en Actividad Evaluable'}">${toggleEvaluableIconSVG}</button>`;
+        const toggleEvaluableIconHTML = isEvaluable
+            ? '<span class="dashicons dashicons-clipboard" style="color: #666; font-size: 20px; width: 20px; height: 20px;"></span>'
+            : '<span class="dashicons dashicons-calculator" style="color: #28a745; font-size: 20px; width: 20px; height: 20px;"></span>';
+
+        let actionsHTML = `<button class="cpp-toggle-evaluable-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="${isEvaluable ? 'Convertir en Tarea (No Evaluable)' : 'Convertir en Actividad Evaluable'}">${toggleEvaluableIconHTML}</button>`;
 
         if (isEvaluable) {
             actionsHTML += `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -166,6 +166,7 @@
         // Actividades
         $document.on('click', '#cpp-add-actividad-no-evaluable-btn', function() { self.addNonEvaluableActividad(this.dataset.sesionId); });
         $document.on('click', '#cpp-add-actividad-evaluable-btn', function() { self.addEvaluableActividad(this.dataset.sesionId); });
+        $document.on('click', '.cpp-toggle-evaluable-btn', function() { self.handleToggleEvaluable(this.dataset.actividadId, this.dataset.tipo); });
         $document.on('click', '.cpp-edit-evaluable-btn', function() { self.editEvaluableActividad(this.dataset.actividadId); });
         $document.on('click', '.cpp-edit-no-evaluable-btn', function() { self.editNonEvaluableActividad(this.dataset.actividadId); });
         $document.on('click', '#cpp-programador-app .cpp-delete-actividad-btn', function() { self.deleteActividad(this.dataset.actividadId, this.dataset.tipo); });
@@ -375,6 +376,111 @@
             },
             error: () => this.applyShareStatus(null)
         });
+    },
+
+    handleToggleEvaluable(actividadId, tipo) {
+        const self = this;
+        const isEvaluable = tipo === 'evaluable';
+        const actividad = this.currentSesion.actividades_programadas.find(a => a.id == actividadId && a.tipo === tipo);
+
+        if (!actividad) return;
+
+        if (isEvaluable) {
+            // Convertir a NO EVALUABLE
+            if (!confirm('¿Estás seguro de que quieres convertir esta actividad en una tarea no evaluable?\n\n¡Se borrarán todas las notas registradas en el cuaderno para esta actividad y no se puede deshacer!')) {
+                return;
+            }
+
+            const data = new URLSearchParams({
+                action: 'cpp_toggle_actividad_evaluable',
+                nonce: cppFrontendData.nonce,
+                actividad_id: actividadId,
+                es_evaluable: 0,
+                tipo: tipo
+            });
+
+            if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
+
+            fetch(cppFrontendData.ajaxUrl, { method: 'POST', body: data })
+                .then(res => res.json())
+                .then(result => {
+                    if (result.success) {
+                        this.showNotification('Actividad convertida en tarea.');
+                        // Actualizar localmente y refrescar
+                        this.refreshCurrentView();
+                        document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
+                    } else {
+                        this.showNotification(result.data.message || 'Error al convertir.', 'error');
+                    }
+                })
+                .finally(() => {
+                    if (cpp.utils && typeof cpp.utils.hideSpinner === 'function') cpp.utils.hideSpinner();
+                });
+        } else {
+            // Convertir a EVALUABLE
+            // Necesitamos pedir el criterio. Reutilizamos el modal de añadir actividad pero quizás es mejor un prompt simple o un modal pequeño si tenemos.
+            // Dado que el sistema usa Criterios Globales, vamos a buscar los criterios de la evaluación actual.
+            const currentEval = this.currentClase.evaluaciones.find(e => e.id == this.currentEvaluacionId);
+            if (!currentEval) return;
+
+            // Si la evaluación no es ponderada, no hace falta elegir criterio (aunque el backend asignará uno por defecto o 'No aplica')
+            if (currentEval.calculo_nota === 'total') {
+                this.executeToggleEvaluable(actividadId, 1, null);
+                return;
+            }
+
+            // Si es ponderada, mostramos un selector simple (usando prompt para agilizar o un modal si prefieres)
+            // Vamos a ver qué criterios tiene esta evaluación
+            const categorias = currentEval.categorias || [];
+            if (categorias.length === 0) {
+                this.showNotification('Esta evaluación no tiene criterios asignados en Ponderaciones. Por favor, asigna uno primero.', 'error');
+                return;
+            }
+
+            let message = 'Selecciona un criterio para esta actividad:\n\n';
+            categorias.forEach((cat, index) => {
+                message += `${index + 1}. ${cat.nombre_categoria}\n`;
+            });
+
+            const choice = prompt(message, "1");
+            if (choice === null) return;
+
+            const index = parseInt(choice) - 1;
+            if (isNaN(index) || !categorias[index]) {
+                this.showNotification('Opción no válida.', 'error');
+                return;
+            }
+
+            this.executeToggleEvaluable(actividadId, 1, categorias[index].criterio_id);
+        }
+    },
+
+    executeToggleEvaluable(actividadId, esEvaluable, criterioId, tipo = 'no_evaluable') {
+        const data = new URLSearchParams({
+            action: 'cpp_toggle_actividad_evaluable',
+            nonce: cppFrontendData.nonce,
+            actividad_id: actividadId,
+            es_evaluable: esEvaluable,
+            criterio_id: criterioId || '',
+            tipo: tipo
+        });
+
+        if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
+
+        fetch(cppFrontendData.ajaxUrl, { method: 'POST', body: data })
+            .then(res => res.json())
+            .then(result => {
+                if (result.success) {
+                    this.showNotification(esEvaluable ? 'Tarea convertida en actividad evaluable.' : 'Actividad convertida en tarea.');
+                    this.refreshCurrentView();
+                    document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
+                } else {
+                    this.showNotification(result.data.message || 'Error al actualizar.', 'error');
+                }
+            })
+            .finally(() => {
+                if (cpp.utils && typeof cpp.utils.hideSpinner === 'function') cpp.utils.hideSpinner();
+            });
     },
 
     handleToggleShare() {
@@ -2182,13 +2288,16 @@
         const isEvaluable = actividad.tipo === 'evaluable';
         const deleteIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z"/></svg>';
         const editIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>';
+        const toggleEvaluableIconSVG = isEvaluable
+            ? '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="#FFD700"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>'
+            : '<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></svg>';
 
-        let actionsHTML = '';
+        let actionsHTML = `<button class="cpp-toggle-evaluable-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="${isEvaluable ? 'Convertir en Tarea (No Evaluable)' : 'Convertir en Actividad Evaluable'}">${toggleEvaluableIconSVG}</button>`;
+
         if (isEvaluable) {
-            actionsHTML = `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
+            actionsHTML += `<button class="cpp-edit-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar en Cuaderno">${editIconSVG}</button>`;
         } else {
-            // --- AÑADIDO: Botón de editar para actividades no evaluables ---
-            actionsHTML = `<button class="cpp-edit-no-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar">${editIconSVG}</button>`;
+            actionsHTML += `<button class="cpp-edit-no-evaluable-btn" data-actividad-id="${actividad.id}" title="Editar">${editIconSVG}</button>`;
         }
 
         actionsHTML += `<button class="cpp-delete-actividad-btn" data-actividad-id="${actividad.id}" data-tipo="${actividad.tipo}" title="Eliminar">

--- a/assets/js/cpp-programador.js
+++ b/assets/js/cpp-programador.js
@@ -391,31 +391,32 @@
                 return;
             }
 
-            const data = new URLSearchParams({
-                action: 'cpp_toggle_actividad_evaluable',
-                nonce: cppFrontendData.nonce,
-                actividad_id: actividadId,
-                es_evaluable: 0,
-                tipo: tipo
-            });
-
             if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
 
-            fetch(cppFrontendData.ajaxUrl, { method: 'POST', body: data })
-                .then(res => res.json())
-                .then(result => {
+            $.ajax({
+                url: cppFrontendData.ajaxUrl,
+                type: 'POST',
+                data: {
+                    action: 'cpp_toggle_actividad_evaluable',
+                    nonce: cppFrontendData.nonce,
+                    actividad_id: actividadId,
+                    es_evaluable: 0,
+                    tipo: tipo
+                },
+                success: (result) => {
                     if (result.success) {
                         this.showNotification('Actividad convertida en tarea.');
-                        // Actualizar localmente y refrescar
                         this.refreshCurrentView();
                         document.dispatchEvent(new CustomEvent('cpp:forceGradebookReload'));
                     } else {
                         this.showNotification(result.data.message || 'Error al convertir.', 'error');
                     }
-                })
-                .finally(() => {
+                },
+                error: () => this.showNotification('Error de conexión.', 'error'),
+                complete: () => {
                     if (cpp.utils && typeof cpp.utils.hideSpinner === 'function') cpp.utils.hideSpinner();
-                });
+                }
+            });
         } else {
             // Convertir a EVALUABLE
             // Necesitamos pedir el criterio. Reutilizamos el modal de añadir actividad pero quizás es mejor un prompt simple o un modal pequeño si tenemos.
@@ -456,20 +457,20 @@
     },
 
     executeToggleEvaluable(actividadId, esEvaluable, criterioId, tipo = 'no_evaluable') {
-        const data = new URLSearchParams({
-            action: 'cpp_toggle_actividad_evaluable',
-            nonce: cppFrontendData.nonce,
-            actividad_id: actividadId,
-            es_evaluable: esEvaluable,
-            criterio_id: criterioId || '',
-            tipo: tipo
-        });
-
         if (cpp.utils && typeof cpp.utils.showSpinner === 'function') cpp.utils.showSpinner();
 
-        fetch(cppFrontendData.ajaxUrl, { method: 'POST', body: data })
-            .then(res => res.json())
-            .then(result => {
+        $.ajax({
+            url: cppFrontendData.ajaxUrl,
+            type: 'POST',
+            data: {
+                action: 'cpp_toggle_actividad_evaluable',
+                nonce: cppFrontendData.nonce,
+                actividad_id: actividadId,
+                es_evaluable: esEvaluable,
+                criterio_id: criterioId || '',
+                tipo: tipo
+            },
+            success: (result) => {
                 if (result.success) {
                     this.showNotification(esEvaluable ? 'Tarea convertida en actividad evaluable.' : 'Actividad convertida en tarea.');
                     this.refreshCurrentView();
@@ -477,10 +478,12 @@
                 } else {
                     this.showNotification(result.data.message || 'Error al actualizar.', 'error');
                 }
-            })
-            .finally(() => {
+            },
+            error: () => this.showNotification('Error de conexión.', 'error'),
+            complete: () => {
                 if (cpp.utils && typeof cpp.utils.hideSpinner === 'function') cpp.utils.hideSpinner();
-            });
+            }
+        });
     },
 
     handleToggleShare() {

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -10,7 +10,7 @@ Author: Javier Vegas Serrano
 defined('ABSPATH') or die('Acceso no permitido');
 
 // --- VERSIÓN ACTUALIZADA PARA LA NUEVA MIGRACIÓN ---
-define('CPP_VERSION', '2.9.1');
+define('CPP_VERSION', '2.9.2');
 
 // Constantes
 define('CPP_PLUGIN_DIR', plugin_dir_path(__FILE__));

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -10,7 +10,7 @@ Author: Javier Vegas Serrano
 defined('ABSPATH') or die('Acceso no permitido');
 
 // --- VERSIÓN ACTUALIZADA PARA LA NUEVA MIGRACIÓN ---
-define('CPP_VERSION', '2.9.0');
+define('CPP_VERSION', '2.9.1');
 
 // Constantes
 define('CPP_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -513,6 +513,11 @@ function cpp_run_migrations() {
         }
     }
 
+    // --- MIGRACIÓN v2.9.1: Asegurar columnas en programador ---
+    if (version_compare($current_version, '2.9.1', '<')) {
+        cpp_migrate_add_programmer_columns_v2_9_1();
+    }
+
     // --- IMPORTANTE: Limpiar caché si la versión ha cambiado (seguridad extra) ---
     if (version_compare($current_version, CPP_VERSION, '<')) {
         delete_metadata('user', 0, 'cpp_programador_all_data_cache', '', true);
@@ -571,6 +576,18 @@ function cpp_migrate_horario_data_v1_8() {
                 ['%d']
             );
         }
+    }
+}
+
+function cpp_migrate_add_programmer_columns_v2_9_1() {
+    global $wpdb;
+    $tabla_prog_act = $wpdb->prefix . 'cpp_programador_actividades';
+
+    if (!$wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM `$tabla_prog_act` LIKE 'es_evaluable'"))) {
+        $wpdb->query("ALTER TABLE `$tabla_prog_act` ADD `es_evaluable` TINYINT(1) NOT NULL DEFAULT 0 AFTER `titulo`;");
+    }
+    if (!$wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM `$tabla_prog_act` LIKE 'actividad_calificable_id'"))) {
+        $wpdb->query("ALTER TABLE `$tabla_prog_act` ADD `actividad_calificable_id` MEDIUMINT(9) UNSIGNED DEFAULT NULL AFTER `es_evaluable`, ADD KEY `actividad_calificable_id` (`actividad_calificable_id`);");
     }
 }
 

--- a/cuaderno-para-profes.php
+++ b/cuaderno-para-profes.php
@@ -10,7 +10,7 @@ Author: Javier Vegas Serrano
 defined('ABSPATH') or die('Acceso no permitido');
 
 // --- VERSIÓN ACTUALIZADA PARA LA NUEVA MIGRACIÓN ---
-define('CPP_VERSION', '2.8.9');
+define('CPP_VERSION', '2.9.0');
 
 // Constantes
 define('CPP_PLUGIN_DIR', plugin_dir_path(__FILE__));

--- a/includes/ajax-handlers/ajax-actividades.php
+++ b/includes/ajax-handlers/ajax-actividades.php
@@ -247,7 +247,11 @@ function cpp_ajax_get_actividades_tab_content() {
                             <td>
                                 <div class="cpp-actividades-actions">
                                     <button class="cpp-btn-icon cpp-btn-toggle-actividad" title="<?php echo $is_evaluable ? 'Convertir en Tarea (No Evaluable)' : 'Convertir en Actividad Evaluable'; ?>">
-                                        <span class="dashicons dashicons-star-<?php echo $is_evaluable ? 'filled' : 'empty'; ?>" style="<?php echo $is_evaluable ? 'color: #FFD700;' : ''; ?>"></span>
+                                        <?php if ($is_evaluable): ?>
+                                            <span class="dashicons dashicons-clipboard" style="color: #666;"></span>
+                                        <?php else: ?>
+                                            <span class="dashicons dashicons-calculator" style="color: #28a745;"></span>
+                                        <?php endif; ?>
                                     </button>
                                     <button class="cpp-btn-icon cpp-btn-delete-actividad" title="Eliminar Actividad">
                                         <span class="dashicons dashicons-trash"></span>

--- a/includes/ajax-handlers/ajax-actividades.php
+++ b/includes/ajax-handlers/ajax-actividades.php
@@ -21,43 +21,90 @@ function cpp_ajax_get_actividades_tab_content() {
     $tabla_clases = $wpdb->prefix . 'cpp_clases';
     $tabla_evaluaciones = $wpdb->prefix . 'cpp_evaluaciones';
     $tabla_criterios = $wpdb->prefix . 'cpp_criterios_globales';
+    $tabla_prog_act = $wpdb->prefix . 'cpp_programador_actividades';
+    $tabla_sesiones = $wpdb->prefix . 'cpp_programador_sesiones';
 
-    $where_clauses = ["a.user_id = $user_id"];
-    if ($clase_id > 0) {
-        $where_clauses[] = $wpdb->prepare("a.clase_id = %d", $clase_id);
+    $actividades_eval = [];
+    $actividades_no_eval = [];
+
+    // --- CARGAR EVALUABLES ---
+    if ($criterio_id >= 0 || $criterio_id == -1 || $criterio_id == -2) {
+        $where_clauses = ["a.user_id = $user_id"];
+        if ($clase_id > 0) $where_clauses[] = $wpdb->prepare("a.clase_id = %d", $clase_id);
+        if ($evaluacion_id > 0) $where_clauses[] = $wpdb->prepare("a.evaluacion_id = %d", $evaluacion_id);
+
+        if ($criterio_id > 0) {
+            $where_clauses[] = $wpdb->prepare("a.criterio_id = %d", $criterio_id);
+        } elseif ($criterio_id == -1) {
+            $where_clauses[] = "(a.criterio_id IS NULL OR a.criterio_id = 0) AND ev.calculo_nota = 'ponderada'";
+        } elseif ($criterio_id == -2) {
+            $where_clauses[] = "ev.calculo_nota = 'total'";
+        }
+
+        $where_sql = implode(' AND ', $where_clauses);
+        $sql = "SELECT a.*, 'evaluable' as tipo_actividad,
+                       c.nombre as clase_nombre, c.color as clase_color,
+                       cg.nombre as nombre_criterio, cg.color as criterio_color,
+                       ev.nombre_evaluacion, ev.calculo_nota
+                FROM $tabla_actividades a
+                INNER JOIN $tabla_clases c ON a.clase_id = c.id
+                LEFT JOIN $tabla_evaluaciones ev ON a.evaluacion_id = ev.id
+                LEFT JOIN $tabla_criterios cg ON a.criterio_id = cg.id
+                WHERE $where_sql
+                ORDER BY a.fecha_actividad DESC, a.id DESC";
+
+        if ($limit > 0) $sql = $wpdb->prepare($sql . " LIMIT %d", $limit);
+        $actividades_eval = $wpdb->get_results($sql, ARRAY_A);
     }
-    if ($evaluacion_id > 0) {
-        $where_clauses[] = $wpdb->prepare("a.evaluacion_id = %d", $evaluacion_id);
+
+    // --- CARGAR NO EVALUABLES ---
+    if ($criterio_id == 0 || $criterio_id == -3) {
+        $where_clauses = ["s.user_id = $user_id", "(pa.es_evaluable = 0 OR pa.es_evaluable IS NULL)"];
+        if ($clase_id > 0) $where_clauses[] = $wpdb->prepare("s.clase_id = %d", $clase_id);
+        if ($evaluacion_id > 0) $where_clauses[] = $wpdb->prepare("s.evaluacion_id = %d", $evaluacion_id);
+
+        $where_sql = implode(' AND ', $where_clauses);
+        $sql = "SELECT pa.id, pa.sesion_id, pa.titulo as nombre_actividad, pa.orden,
+                       'no_evaluable' as tipo_actividad,
+                       s.clase_id, s.evaluacion_id,
+                       c.nombre as clase_nombre, c.color as clase_color,
+                       ev.nombre_evaluacion, ev.calculo_nota,
+                       NULL as fecha_actividad, NULL as nota_maxima, NULL as descripcion_actividad
+                FROM $tabla_prog_act pa
+                INNER JOIN $tabla_sesiones s ON pa.sesion_id = s.id
+                INNER JOIN $tabla_clases c ON s.clase_id = c.id
+                LEFT JOIN $tabla_evaluaciones ev ON s.evaluacion_id = ev.id
+                WHERE $where_sql
+                ORDER BY pa.id DESC";
+
+        if ($limit > 0) $sql = $wpdb->prepare($sql . " LIMIT %d", $limit);
+        $actividades_no_eval = $wpdb->get_results($sql, ARRAY_A);
+
+        // Hidratar fechas para no evaluables
+        if (!empty($actividades_no_eval)) {
+            require_once CPP_PLUGIN_DIR . 'includes/programador/db-programador.php';
+            foreach ($actividades_no_eval as &$act) {
+                $fechas = cpp_programador_get_fechas_for_evaluacion($user_id, $act['clase_id'], $act['evaluacion_id']);
+                if (isset($fechas[$act['sesion_id']])) {
+                    $act['fecha_actividad'] = $fechas[$act['sesion_id']]['fecha'];
+                }
+            }
+        }
     }
-    if ($criterio_id > 0) {
-        $where_clauses[] = $wpdb->prepare("a.criterio_id = %d", $criterio_id);
-    } elseif ($criterio_id == -1) {
-        // Sin asignar criterio: Ponderada + Sin Criterio
-        $where_clauses[] = "(a.criterio_id IS NULL OR a.criterio_id = 0) AND ev.calculo_nota = 'ponderada'";
-    } elseif ($criterio_id == -2) {
-        // No aplica: Evaluación de tipo 'total'
-        $where_clauses[] = "ev.calculo_nota = 'total'";
+
+    // Mezclar y ordenar
+    $actividades = array_merge($actividades_eval, $actividades_no_eval);
+    usort($actividades, function($a, $b) {
+        $fechaA = $a['fecha_actividad'] ?: '0000-00-00';
+        $fechaB = $b['fecha_actividad'] ?: '0000-00-00';
+        if ($fechaA == $fechaB) return $b['id'] - $a['id'];
+        return strcmp($fechaB, $fechaA);
+    });
+
+    if ($limit > 0 && count($actividades) > $limit) {
+        $actividades = array_slice($actividades, 0, $limit);
     }
 
-    $where_sql = implode(' AND ', $where_clauses);
-
-    // Obtenemos actividades con info de clase y criterio
-    $sql = "SELECT a.*,
-                   c.nombre as clase_nombre, c.color as clase_color,
-                   cg.nombre as nombre_criterio, cg.color as criterio_color,
-                   ev.nombre_evaluacion, ev.calculo_nota
-            FROM $tabla_actividades a
-            INNER JOIN $tabla_clases c ON a.clase_id = c.id
-            LEFT JOIN $tabla_evaluaciones ev ON a.evaluacion_id = ev.id
-            LEFT JOIN $tabla_criterios cg ON a.criterio_id = cg.id
-            WHERE $where_sql
-            ORDER BY a.fecha_actividad DESC, a.id DESC";
-
-    if ($limit > 0) {
-        $sql = $wpdb->prepare($sql . " LIMIT %d", $limit);
-    }
-
-    $actividades = $wpdb->get_results($sql, ARRAY_A);
     $counts = cpp_get_global_criterion_counts($user_id);
 
     if (empty($actividades)) {
@@ -137,12 +184,16 @@ function cpp_ajax_get_actividades_tab_content() {
             </thead>
             <tbody>
                 <?php foreach ($actividades as $act) :
+                    $tipo = $act['tipo_actividad'];
+                    $is_evaluable = ($tipo === 'evaluable');
                     $promedio = isset($mapa_promedios[$act['id']]) ? $mapa_promedios[$act['id']] : null;
                     $criterio_color = !empty($act['criterio_color']) ? $act['criterio_color'] : '#FFFFFF';
                     $is_programada = !empty($act['sesion_id']);
                     $clase_color = !empty($act['clase_color']) ? $act['clase_color'] : '#CCCCCC';
                 ?>
-                        <tr data-actividad-id="<?php echo esc_attr($act['id']); ?>" data-evaluacion-id="<?php echo esc_attr($act['evaluacion_id']); ?>">
+                        <tr data-actividad-id="<?php echo esc_attr($act['id']); ?>"
+                            data-evaluacion-id="<?php echo esc_attr($act['evaluacion_id']); ?>"
+                            data-tipo="<?php echo esc_attr($tipo); ?>">
                             <td data-sort-value="<?php echo esc_attr($act['clase_nombre']); ?>">
                                 <div class="cpp-actividad-clase-cell">
                                     <span class="cpp-clase-color-strip" style="background-color: <?php echo esc_attr($clase_color); ?>;"></span>
@@ -152,9 +203,11 @@ function cpp_ajax_get_actividades_tab_content() {
                             <td data-sort-value="<?php echo esc_attr($act['nombre_actividad']); ?>">
                                 <input type="text" class="cpp-inline-edit" data-field="nombre_actividad" value="<?php echo esc_attr($act['nombre_actividad']); ?>" placeholder="Nombre de la actividad">
                             </td>
-                            <td data-sort-value="<?php echo esc_attr($act['nombre_criterio'] ?: ($act['calculo_nota'] === 'total' ? 'No aplica' : 'Sin asignar criterio')); ?>">
+                            <td data-sort-value="<?php echo esc_attr($act['nombre_criterio'] ?: ($act['calculo_nota'] === 'total' ? 'No aplica' : ($is_evaluable ? 'Sin asignar criterio' : 'Tarea (No evaluable)'))); ?>">
                                 <div class="cpp-actividad-categoria-cell">
-                                    <?php if ($act['calculo_nota'] === 'total') : ?>
+                                    <?php if (!$is_evaluable) : ?>
+                                        <span class="cpp-no-evaluable-badge">Tarea</span>
+                                    <?php elseif ($act['calculo_nota'] === 'total') : ?>
                                         <span class="cpp-no-aplica-badge">No aplica</span>
                                     <?php else : ?>
                                         <span class="cpp-category-dot" style="background-color: <?php echo esc_attr($criterio_color); ?>;"></span>
@@ -175,18 +228,31 @@ function cpp_ajax_get_actividades_tab_content() {
                                 </div>
                             </td>
                             <td data-sort-value="<?php echo esc_attr($act['nota_maxima']); ?>">
-                                <input type="number" class="cpp-inline-edit" data-field="nota_maxima" value="<?php echo esc_attr($act['nota_maxima']); ?>" step="0.01" min="0.01">
+                                <?php if ($is_evaluable) : ?>
+                                    <input type="number" class="cpp-inline-edit" data-field="nota_maxima" value="<?php echo esc_attr($act['nota_maxima']); ?>" step="0.01" min="0.01">
+                                <?php else : ?>
+                                    <span class="cpp-na-text">-</span>
+                                <?php endif; ?>
                             </td>
                             <td data-sort-value="<?php echo esc_attr($act['descripcion_actividad']); ?>">
-                                <textarea class="cpp-inline-edit" data-field="descripcion_actividad" rows="1" placeholder="Añade una descripción..."><?php echo esc_textarea($act['descripcion_actividad']); ?></textarea>
+                                <?php if ($is_evaluable) : ?>
+                                    <textarea class="cpp-inline-edit" data-field="descripcion_actividad" rows="1" placeholder="Añade una descripción..."><?php echo esc_textarea($act['descripcion_actividad']); ?></textarea>
+                                <?php else : ?>
+                                    <span class="cpp-na-text">-</span>
+                                <?php endif; ?>
                             </td>
                             <td class="cpp-actividad-promedio" data-sort-value="<?php echo esc_attr($promedio !== null ? $promedio : -1); ?>">
                                 <strong><?php echo $promedio !== null ? cpp_formatear_nota_display($promedio) : '-'; ?></strong>
                             </td>
                             <td>
-                                <button class="cpp-btn-icon cpp-btn-delete-actividad" title="Eliminar Actividad">
-                                    <span class="dashicons dashicons-trash"></span>
-                                </button>
+                                <div class="cpp-actividades-actions">
+                                    <button class="cpp-btn-icon cpp-btn-toggle-actividad" title="<?php echo $is_evaluable ? 'Convertir en Tarea (No Evaluable)' : 'Convertir en Actividad Evaluable'; ?>">
+                                        <span class="dashicons dashicons-star-<?php echo $is_evaluable ? 'filled' : 'empty'; ?>" style="<?php echo $is_evaluable ? 'color: #FFD700;' : ''; ?>"></span>
+                                    </button>
+                                    <button class="cpp-btn-icon cpp-btn-delete-actividad" title="Eliminar Actividad">
+                                        <span class="dashicons dashicons-trash"></span>
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                     <?php endforeach; ?>
@@ -199,7 +265,8 @@ function cpp_ajax_get_actividades_tab_content() {
         'html' => $html,
         'criterios' => $counts['criterios'],
         'num_sin_criterio' => $counts['num_sin_criterio'],
-        'num_no_aplica' => $counts['num_no_aplica']
+        'num_no_aplica' => $counts['num_no_aplica'],
+        'num_no_evaluables' => $counts['num_no_evaluables']
     ]);
 }
 
@@ -213,6 +280,7 @@ function cpp_ajax_actualizar_actividad_inline() {
     $evaluacion_id = isset($_POST['evaluacion_id']) ? intval($_POST['evaluacion_id']) : 0;
     $field = isset($_POST['field']) ? sanitize_text_field($_POST['field']) : '';
     $value = isset($_POST['value']) ? $_POST['value'] : '';
+    $tipo = isset($_POST['tipo']) ? sanitize_text_field($_POST['tipo']) : 'evaluable';
 
     if (empty($actividad_id) || empty($field)) {
         wp_send_json_error(['message' => 'Datos incompletos.']);
@@ -251,7 +319,25 @@ function cpp_ajax_actualizar_actividad_inline() {
     // Si actualizamos categoría o nota máxima, necesitamos forzar el recalculo de notas finales en el frontend
     // pero eso lo manejaremos con una señal de recarga.
 
-    $resultado = cpp_actualizar_actividad_evaluable($actividad_id, $datos);
+    $resultado = false;
+    if ($tipo === 'no_evaluable') {
+        global $wpdb;
+        $tabla_prog_act = $wpdb->prefix . 'cpp_programador_actividades';
+        // Verificar propiedad de la sesión
+        $sesion_id = $wpdb->get_var($wpdb->prepare("SELECT sesion_id FROM $tabla_prog_act WHERE id = %d", $actividad_id));
+        if ($sesion_id) {
+            require_once CPP_PLUGIN_DIR . 'includes/programador/db-programador.php';
+            $owner_id = cpp_programador_get_sesion_owner($sesion_id);
+            if ($owner_id == $user_id) {
+                if ($field === 'nombre_actividad') {
+                    $resultado = $wpdb->update($tabla_prog_act, ['titulo' => $datos['nombre_actividad']], ['id' => $actividad_id]);
+                    $resultado = ($resultado !== false);
+                }
+            }
+        }
+    } else {
+        $resultado = cpp_actualizar_actividad_evaluable($actividad_id, $datos);
+    }
 
     if ($resultado !== false) {
         $counts = cpp_get_global_criterion_counts($user_id);
@@ -259,7 +345,8 @@ function cpp_ajax_actualizar_actividad_inline() {
             'message' => 'Actividad actualizada.',
             'criterios' => $counts['criterios'],
             'num_sin_criterio' => $counts['num_sin_criterio'],
-            'num_no_aplica' => $counts['num_no_aplica']
+            'num_no_aplica' => $counts['num_no_aplica'],
+            'num_no_evaluables' => $counts['num_no_evaluables']
         ]);
     } else {
         wp_send_json_error(['message' => 'Error al actualizar la actividad.']);
@@ -273,13 +360,20 @@ function cpp_ajax_eliminar_actividad() {
 
     $user_id = get_current_user_id();
     $actividad_id = isset($_POST['actividad_id']) ? intval($_POST['actividad_id']) : 0;
+    $tipo = isset($_POST['tipo']) ? sanitize_text_field($_POST['tipo']) : 'evaluable';
 
     if (empty($actividad_id)) {
         wp_send_json_error(['message' => 'ID de actividad no proporcionado.']);
         return;
     }
 
-    $resultado = cpp_eliminar_actividad_y_calificaciones($actividad_id, $user_id);
+    $resultado = false;
+    if ($tipo === 'no_evaluable') {
+        require_once CPP_PLUGIN_DIR . 'includes/programador/db-programador.php';
+        $resultado = cpp_programador_delete_actividad($actividad_id, $user_id);
+    } else {
+        $resultado = cpp_eliminar_actividad_y_calificaciones($actividad_id, $user_id);
+    }
 
     if ($resultado) {
         $counts = cpp_get_global_criterion_counts($user_id);
@@ -287,7 +381,8 @@ function cpp_ajax_eliminar_actividad() {
             'message' => 'Actividad eliminada correctamente.',
             'criterios' => $counts['criterios'],
             'num_sin_criterio' => $counts['num_sin_criterio'],
-            'num_no_aplica' => $counts['num_no_aplica']
+            'num_no_aplica' => $counts['num_no_aplica'],
+            'num_no_evaluables' => $counts['num_no_evaluables']
         ]);
     } else {
         wp_send_json_error(['message' => 'Error al eliminar la actividad o no tienes permiso.']);

--- a/includes/db-queries/queries-criterios.php
+++ b/includes/db-queries/queries-criterios.php
@@ -63,10 +63,21 @@ function cpp_get_global_criterion_counts($user_id) {
           AND e.calculo_nota = 'total'
     ", $user_id));
 
+    // Contar tareas NO evaluables (del programador)
+    $tabla_prog_act = $wpdb->prefix . 'cpp_programador_actividades';
+    $tabla_sesiones = $wpdb->prefix . 'cpp_programador_sesiones';
+    $num_no_evaluables = $wpdb->get_var($wpdb->prepare("
+        SELECT COUNT(*)
+        FROM $tabla_prog_act pa
+        INNER JOIN $tabla_sesiones s ON pa.sesion_id = s.id
+        WHERE s.user_id = %d AND (pa.es_evaluable = 0 OR pa.es_evaluable IS NULL)
+    ", $user_id));
+
     return [
         'criterios' => $criterios_globales,
         'num_sin_criterio' => $num_sin_criterio,
-        'num_no_aplica' => $num_no_aplica
+        'num_no_aplica' => intval($num_no_aplica),
+        'num_no_evaluables' => intval($num_no_evaluables)
     ];
 }
 

--- a/includes/db.php
+++ b/includes/db.php
@@ -200,9 +200,12 @@ function cpp_crear_tablas() {
         id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
         sesion_id bigint(20) UNSIGNED NOT NULL,
         titulo varchar(255) NOT NULL,
+        es_evaluable tinyint(1) NOT NULL DEFAULT 0,
+        actividad_calificable_id mediumint(9) UNSIGNED DEFAULT NULL,
         orden int NOT NULL DEFAULT 0,
         PRIMARY KEY (id),
-        KEY sesion_id (sesion_id)
+        KEY sesion_id (sesion_id),
+        KEY actividad_calificable_id (actividad_calificable_id)
     ) $charset_collate;";
     dbDelta($sql_programador_actividades);
 

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -292,7 +292,7 @@ function cpp_ajax_save_programador_actividad() {
         $actividad_guardada = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_actividades WHERE id = %d", $result_id), ARRAY_A);
 
         if ($actividad_guardada) {
-            $actividad_guardada['tipo'] = 'no_evaluable';
+            $actividad_guardada['tipo'] = $actividad_guardada['es_evaluable'] ? 'evaluable' : 'no_evaluable';
         }
 
         wp_send_json_success(['message' => 'Actividad guardada.', 'actividad' => $actividad_guardada, 'needs_gradebook_reload' => true]);
@@ -341,6 +341,7 @@ function cpp_ajax_toggle_actividad_evaluable() {
     $actividad_id = isset($_POST['actividad_id']) ? intval($_POST['actividad_id']) : 0;
     $es_evaluable = isset($_POST['es_evaluable']) ? intval($_POST['es_evaluable']) : 0;
     $categoria_id = isset($_POST['categoria_id']) ? intval($_POST['categoria_id']) : null;
+    $tipo_actual = isset($_POST['tipo']) ? sanitize_text_field($_POST['tipo']) : '';
 
     if (empty($actividad_id)) {
         wp_send_json_error(['message' => 'ID de actividad no válido.']);
@@ -349,12 +350,44 @@ function cpp_ajax_toggle_actividad_evaluable() {
 
     global $wpdb;
     $tabla_programador_actividades = $wpdb->prefix . 'cpp_programador_actividades';
-    $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id));
+    $tabla_evaluables = $wpdb->prefix . 'cpp_actividades_evaluables';
+    $actividad_prog = null;
+    $actividad_cuaderno = null;
+
+    if ($tipo_actual === 'evaluable') {
+        // El ID proporcionado es el del cuaderno
+        $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
+        if (!$actividad_cuaderno) {
+            wp_send_json_error(['message' => 'Actividad evaluable no encontrada.']);
+            return;
+        }
+        // Intentar encontrar la entrada correspondiente en el programador
+        $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
+
+        if (!$actividad_prog && $actividad_cuaderno->sesion_id) {
+            // Si no existe pero tiene sesion_id, es una actividad creada directamente en el cuaderno vinculada a una sesión.
+            // Para poder convertirla en no evaluable (tarea), necesitamos crear la entrada en el programador.
+            $wpdb->insert($tabla_programador_actividades, [
+                'sesion_id' => $actividad_cuaderno->sesion_id,
+                'titulo' => $actividad_cuaderno->nombre_actividad,
+                'es_evaluable' => 1,
+                'actividad_calificable_id' => $actividad_cuaderno->id,
+                'orden' => $actividad_cuaderno->orden
+            ]);
+            $new_prog_id = $wpdb->insert_id;
+            $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
+        }
+    } else {
+        // El ID proporcionado es el del programador
+        $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id));
+    }
 
     if (!$actividad_prog) {
-        wp_send_json_error(['message' => 'Actividad no encontrada.']);
+        wp_send_json_error(['message' => 'No se pudo encontrar la referencia en la programación para esta actividad.']);
         return;
     }
+
+    $actividad_id = $actividad_prog->id; // Usamos siempre el ID del programador a partir de aquí
 
     // Security Check
     $sesion_owner_id = cpp_programador_get_sesion_owner($actividad_prog->sesion_id);
@@ -429,9 +462,21 @@ function cpp_ajax_toggle_actividad_evaluable() {
         // FIX: Devolver los IDs para que el frontend pueda renderizar el selector correctamente.
         $actividad_actualizada['categoria_id'] = $categoria_id;
         $actividad_actualizada['criterio_id'] = $criterio_id;
+        $actividad_actualizada['tipo'] = $actividad_actualizada['es_evaluable'] ? 'evaluable' : 'no_evaluable';
     }
 
-    wp_send_json_success(['message' => 'Estado actualizado.', 'actividad' => $actividad_actualizada]);
+    // Recalcular contadores globales para la vista de actividades
+    require_once CPP_PLUGIN_DIR . 'includes/db-queries/queries-criterios.php';
+    $counts = cpp_get_global_criterion_counts($user_id);
+
+    wp_send_json_success([
+        'message' => 'Estado actualizado.',
+        'actividad' => $actividad_actualizada,
+        'criterios' => $counts['criterios'],
+        'num_sin_criterio' => $counts['num_sin_criterio'],
+        'num_no_aplica' => $counts['num_no_aplica'],
+        'num_no_evaluables' => $counts['num_no_evaluables']
+    ]);
 }
 
 function cpp_ajax_check_schedule_conflict_handler() {

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -357,33 +357,63 @@ function cpp_ajax_toggle_actividad_evaluable() {
     if ($tipo_actual === 'evaluable') {
         // El ID proporcionado es el del cuaderno
         $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
-        if (!$actividad_cuaderno) {
-            wp_send_json_error(['message' => 'Actividad evaluable no encontrada.']);
-            return;
-        }
-        // Intentar encontrar la entrada correspondiente en el programador
-        $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
+        if ($actividad_cuaderno) {
+            // Intentar encontrar la entrada correspondiente en el programador
+            $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
 
-        if (!$actividad_prog && $actividad_cuaderno->sesion_id) {
-            // Si no existe pero tiene sesion_id, es una actividad creada directamente en el cuaderno vinculada a una sesión.
-            // Para poder convertirla en no evaluable (tarea), necesitamos crear la entrada en el programador.
-            $wpdb->insert($tabla_programador_actividades, [
-                'sesion_id' => $actividad_cuaderno->sesion_id,
-                'titulo' => $actividad_cuaderno->nombre_actividad,
-                'es_evaluable' => 1,
-                'actividad_calificable_id' => $actividad_cuaderno->id,
-                'orden' => $actividad_cuaderno->orden
-            ]);
-            $new_prog_id = $wpdb->insert_id;
-            $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
+            if (!$actividad_prog && $actividad_cuaderno->sesion_id) {
+                // Si no existe pero tiene sesion_id, es una actividad creada directamente en el cuaderno vinculada a una sesión.
+                // Para poder convertirla en no evaluable (tarea), necesitamos crear la entrada en el programador.
+                $wpdb->insert($tabla_programador_actividades, [
+                    'sesion_id' => $actividad_cuaderno->sesion_id,
+                    'titulo' => $actividad_cuaderno->nombre_actividad,
+                    'es_evaluable' => 1,
+                    'actividad_calificable_id' => $actividad_cuaderno->id,
+                    'orden' => $actividad_cuaderno->orden
+                ]);
+                $new_prog_id = $wpdb->insert_id;
+                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
+            }
         }
-    } else {
-        // El ID proporcionado es el del programador
+    }
+
+    // Si no se ha encontrado todavía (o tipo no era evaluable), buscar por ID en la tabla del programador
+    if (!$actividad_prog) {
         $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id));
+
+        // Fallback final: si todavía no lo encontramos y el ID podría ser del cuaderno, intentarlo de nuevo por si acaso falló la detección del tipo
+        if (!$actividad_prog && $tipo_actual !== 'evaluable') {
+            $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
+            if ($actividad_cuaderno && $actividad_cuaderno->sesion_id) {
+                // Intentar buscar de nuevo en el programador por actividad_calificable_id
+                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
+                if (!$actividad_prog) {
+                    $wpdb->insert($tabla_programador_actividades, [
+                        'sesion_id' => $actividad_cuaderno->sesion_id,
+                        'titulo' => $actividad_cuaderno->nombre_actividad,
+                        'es_evaluable' => 1,
+                        'actividad_calificable_id' => $actividad_cuaderno->id,
+                        'orden' => $actividad_cuaderno->orden
+                    ]);
+                    $new_prog_id = $wpdb->insert_id;
+                    $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
+                }
+            }
+        }
     }
 
     if (!$actividad_prog) {
-        wp_send_json_error(['message' => 'No se pudo encontrar la referencia en la programación para esta actividad.']);
+        // Log para depuración silenciosa si el profesor tiene problemas
+        error_log("CPP ERROR: Conversion failed. Actividad ID $actividad_id not found in Programmer table. User $user_id. Type $tipo_actual.");
+
+        wp_send_json_error([
+            'message' => 'No se pudo encontrar la referencia en la programación para esta actividad.',
+            'debug_info' => [
+                'id' => $actividad_id,
+                'type' => $tipo_actual,
+                'user' => $user_id
+            ]
+        ]);
         return;
     }
 

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -333,6 +333,18 @@ function cpp_ajax_save_programador_actividades_order() {
     }
 }
 
+/**
+ * Helper para reintentar la conversión con el tipo opuesto si el primero falla.
+ */
+function cpp_ajax_toggle_actividad_evaluable_retry($id, $tipo, $es_evaluable, $criterio_id, $categoria_id) {
+    $_POST['actividad_id'] = $id;
+    $_POST['tipo'] = $tipo;
+    $_POST['es_evaluable'] = $es_evaluable;
+    $_POST['criterio_id'] = $criterio_id;
+    $_POST['categoria_id'] = $categoria_id;
+    return cpp_ajax_toggle_actividad_evaluable();
+}
+
 function cpp_ajax_toggle_actividad_evaluable() {
     check_ajax_referer('cpp_frontend_nonce', 'nonce');
     if (!is_user_logged_in()) { wp_send_json_error(['message' => 'Usuario no autenticado.']); return; }
@@ -340,6 +352,7 @@ function cpp_ajax_toggle_actividad_evaluable() {
     $user_id = get_current_user_id();
     $actividad_id = isset($_POST['actividad_id']) ? intval($_POST['actividad_id']) : 0;
     $es_evaluable = isset($_POST['es_evaluable']) ? intval($_POST['es_evaluable']) : 0;
+    $criterio_id = isset($_POST['criterio_id']) ? intval($_POST['criterio_id']) : null;
     $categoria_id = isset($_POST['categoria_id']) ? intval($_POST['categoria_id']) : null;
     $tipo_actual = isset($_POST['tipo']) ? sanitize_text_field($_POST['tipo']) : '';
 
@@ -349,70 +362,52 @@ function cpp_ajax_toggle_actividad_evaluable() {
     }
 
     global $wpdb;
-    $tabla_programador_actividades = $wpdb->prefix . 'cpp_programador_actividades';
+    $tabla_prog_act = $wpdb->prefix . 'cpp_programador_actividades';
     $tabla_evaluables = $wpdb->prefix . 'cpp_actividades_evaluables';
     $actividad_prog = null;
     $actividad_cuaderno = null;
 
-    if ($tipo_actual === 'evaluable') {
-        // El ID proporcionado es el del cuaderno
+    // 1. Intentar buscar por el ID proporcionado en la tabla del programador
+    $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $actividad_id));
+
+    // 2. Si no se encuentra, pero el tipo_actual era 'evaluable' (o no venía), buscar en el cuaderno
+    if (!$actividad_prog && ($tipo_actual === 'evaluable' || empty($tipo_actual))) {
         $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
         if ($actividad_cuaderno) {
-            // Intentar encontrar la entrada correspondiente en el programador
-            $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
+            // Buscamos si ya tiene entrada en el programador
+            $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE actividad_calificable_id = %d", $actividad_cuaderno->id));
 
+            // Si no tiene, pero está vinculada a una sesión, la creamos al vuelo
             if (!$actividad_prog && $actividad_cuaderno->sesion_id) {
-                // Si no existe pero tiene sesion_id, es una actividad creada directamente en el cuaderno vinculada a una sesión.
-                // Para poder convertirla en no evaluable (tarea), necesitamos crear la entrada en el programador.
-                $wpdb->insert($tabla_programador_actividades, [
+                $wpdb->insert($tabla_prog_act, [
                     'sesion_id' => $actividad_cuaderno->sesion_id,
                     'titulo' => $actividad_cuaderno->nombre_actividad,
                     'es_evaluable' => 1,
                     'actividad_calificable_id' => $actividad_cuaderno->id,
                     'orden' => $actividad_cuaderno->orden
                 ]);
-                $new_prog_id = $wpdb->insert_id;
-                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
+                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $wpdb->insert_id));
             }
         }
     }
 
-    // Si no se ha encontrado todavía (o tipo no era evaluable), buscar por ID en la tabla del programador
+    // 3. Fallback: Si todavía no hay suerte, buscar por el ID en la tabla contraria
     if (!$actividad_prog) {
-        $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id));
-
-        // Fallback final: si todavía no lo encontramos y el ID podría ser del cuaderno, intentarlo de nuevo por si acaso falló la detección del tipo
-        if (!$actividad_prog && $tipo_actual !== 'evaluable') {
+        if ($tipo_actual === 'no_evaluable') {
             $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
-            if ($actividad_cuaderno && $actividad_cuaderno->sesion_id) {
-                // Intentar buscar de nuevo en el programador por actividad_calificable_id
-                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE actividad_calificable_id = %d", $actividad_id));
-                if (!$actividad_prog) {
-                    $wpdb->insert($tabla_programador_actividades, [
-                        'sesion_id' => $actividad_cuaderno->sesion_id,
-                        'titulo' => $actividad_cuaderno->nombre_actividad,
-                        'es_evaluable' => 1,
-                        'actividad_calificable_id' => $actividad_cuaderno->id,
-                        'orden' => $actividad_cuaderno->orden
-                    ]);
-                    $new_prog_id = $wpdb->insert_id;
-                    $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $new_prog_id));
-                }
+            if ($actividad_cuaderno) {
+                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE actividad_calificable_id = %d", $actividad_cuaderno->id));
             }
+        } else {
+             $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $actividad_id));
         }
     }
 
     if (!$actividad_prog) {
-        // Log para depuración silenciosa si el profesor tiene problemas
-        error_log("CPP ERROR: Conversion failed. Actividad ID $actividad_id not found in Programmer table. User $user_id. Type $tipo_actual.");
-
+        error_log("CPP ERROR: Conversion failed completely. Actividad ID $actividad_id. User $user_id. Type $tipo_actual.");
         wp_send_json_error([
             'message' => 'No se pudo encontrar la referencia en la programación para esta actividad.',
-            'debug_info' => [
-                'id' => $actividad_id,
-                'type' => $tipo_actual,
-                'user' => $user_id
-            ]
+            'debug_info' => ['id' => $actividad_id, 'type' => $tipo_actual, 'u' => $user_id]
         ]);
         return;
     }

--- a/includes/programador/ajax-programador.php
+++ b/includes/programador/ajax-programador.php
@@ -350,13 +350,13 @@ function cpp_ajax_toggle_actividad_evaluable() {
     if (!is_user_logged_in()) { wp_send_json_error(['message' => 'Usuario no autenticado.']); return; }
     cpp_clear_programador_cache(get_current_user_id());
     $user_id = get_current_user_id();
-    $actividad_id = isset($_POST['actividad_id']) ? intval($_POST['actividad_id']) : 0;
-    $es_evaluable = isset($_POST['es_evaluable']) ? intval($_POST['es_evaluable']) : 0;
+    $id_recibido = isset($_POST['actividad_id']) ? intval($_POST['actividad_id']) : 0;
+    $es_evaluable_nuevo_estado = isset($_POST['es_evaluable']) ? intval($_POST['es_evaluable']) : 0;
     $criterio_id = isset($_POST['criterio_id']) ? intval($_POST['criterio_id']) : null;
     $categoria_id = isset($_POST['categoria_id']) ? intval($_POST['categoria_id']) : null;
     $tipo_actual = isset($_POST['tipo']) ? sanitize_text_field($_POST['tipo']) : '';
 
-    if (empty($actividad_id)) {
+    if (empty($id_recibido)) {
         wp_send_json_error(['message' => 'ID de actividad no válido.']);
         return;
     }
@@ -367,18 +367,17 @@ function cpp_ajax_toggle_actividad_evaluable() {
     $actividad_prog = null;
     $actividad_cuaderno = null;
 
-    // 1. Intentar buscar por el ID proporcionado en la tabla del programador
-    $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $actividad_id));
+    // --- PASO 1: LOCALIZAR LA ACTIVIDAD DE FORMA DETERMINISTA ---
 
-    // 2. Si no se encuentra, pero el tipo_actual era 'evaluable' (o no venía), buscar en el cuaderno
-    if (!$actividad_prog && ($tipo_actual === 'evaluable' || empty($tipo_actual))) {
-        $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
+    if ($tipo_actual === 'evaluable') {
+        // El ID es del cuaderno. Buscamos el registro del cuaderno.
+        $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $id_recibido, $user_id));
         if ($actividad_cuaderno) {
-            // Buscamos si ya tiene entrada en el programador
+            // Buscamos su shadow record en el programador
             $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE actividad_calificable_id = %d", $actividad_cuaderno->id));
 
-            // Si no tiene, pero está vinculada a una sesión, la creamos al vuelo
-            if (!$actividad_prog && $actividad_cuaderno->sesion_id) {
+            // Si no existe pero tiene sesion_id, lo creamos ahora
+            if (!$actividad_prog && !empty($actividad_cuaderno->sesion_id)) {
                 $wpdb->insert($tabla_prog_act, [
                     'sesion_id' => $actividad_cuaderno->sesion_id,
                     'titulo' => $actividad_cuaderno->nombre_actividad,
@@ -389,102 +388,92 @@ function cpp_ajax_toggle_actividad_evaluable() {
                 $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $wpdb->insert_id));
             }
         }
-    }
-
-    // 3. Fallback: Si todavía no hay suerte, buscar por el ID en la tabla contraria
-    if (!$actividad_prog) {
-        if ($tipo_actual === 'no_evaluable') {
-            $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_id, $user_id));
-            if ($actividad_cuaderno) {
-                $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE actividad_calificable_id = %d", $actividad_cuaderno->id));
+    } else {
+        // El ID es del programador. Buscamos el registro del programador.
+        $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $id_recibido));
+        if ($actividad_prog) {
+            // Verificamos propiedad de la sesión
+            $owner_id = cpp_programador_get_sesion_owner($actividad_prog->sesion_id);
+            if ($owner_id != $user_id) {
+                wp_send_json_error(['message' => 'No tienes permiso sobre esta sesión.']);
+                return;
             }
-        } else {
-             $actividad_prog = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $actividad_id));
+            if ($actividad_prog->actividad_calificable_id) {
+                $actividad_cuaderno = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_evaluables WHERE id = %d AND user_id = %d", $actividad_prog->actividad_calificable_id, $user_id));
+            }
         }
     }
 
+    // --- PASO 2: VALIDAR QUE HEMOS ENCONTRADO ALGO ---
     if (!$actividad_prog) {
-        error_log("CPP ERROR: Conversion failed completely. Actividad ID $actividad_id. User $user_id. Type $tipo_actual.");
+        error_log("CPP ERROR: Conversion failed. Could not locate Programmer record. ID: $id_recibido, Type: $tipo_actual, User: $user_id");
         wp_send_json_error([
             'message' => 'No se pudo encontrar la referencia en la programación para esta actividad.',
-            'debug_info' => ['id' => $actividad_id, 'type' => $tipo_actual, 'u' => $user_id]
+            'debug' => "ID: $id_recibido, T: $tipo_actual"
         ]);
         return;
     }
 
-    $actividad_id = $actividad_prog->id; // Usamos siempre el ID del programador a partir de aquí
+    $actividad_id_prog = $actividad_prog->id;
 
-    // Security Check
-    $sesion_owner_id = cpp_programador_get_sesion_owner($actividad_prog->sesion_id);
-    if ($sesion_owner_id != $user_id) {
-        wp_send_json_error(['message' => 'Permiso denegado.']);
-        return;
-    }
+    // --- PASO 3: REALIZAR LA CONVERSIÓN ---
 
-    if ($es_evaluable) {
-        // --- Marcar como EVALUABLE ---
-        // La fecha ya no se calcula aquí. Se guardará como NULL y se hidratará al leer.
+    if ($es_evaluable_nuevo_estado) {
+        // --- CONVERTIR A EVALUABLE ---
         $tabla_sesiones = $wpdb->prefix . 'cpp_programador_sesiones';
         $sesion_info = $wpdb->get_row($wpdb->prepare("SELECT clase_id, evaluacion_id FROM $tabla_sesiones WHERE id = %d", $actividad_prog->sesion_id));
 
-        $criterio_id = isset($_POST['criterio_id']) ? intval($_POST['criterio_id']) : null;
-
         if (!$criterio_id && !$categoria_id) {
-            // Fallback para legacy o si no se envía criterio
             $tabla_eval_crit = $wpdb->prefix . 'cpp_evaluacion_criterios';
             $criterio_id = $wpdb->get_var($wpdb->prepare("SELECT criterio_id FROM $tabla_eval_crit WHERE evaluacion_id = %d ORDER BY id ASC LIMIT 1", $sesion_info->evaluacion_id));
-
-            if (!$criterio_id) {
-                wp_send_json_error(['message' => 'No se encontró un criterio asignado para esta evaluación. Por favor, asigna uno en Ponderaciones.']);
-                return;
-            }
         }
 
-        $datos_actividad_calificable = [
-            'id' => $actividad_prog->actividad_calificable_id, // Puede ser null si es nueva
+        $datos_cuaderno = [
             'clase_id' => $sesion_info->clase_id,
             'evaluacion_id' => $sesion_info->evaluacion_id,
-            'categoria_id' => $categoria_id ? $categoria_id : 0,
+            'categoria_id' => $categoria_id ?: 0,
             'criterio_id' => $criterio_id,
             'nombre_actividad' => $actividad_prog->titulo,
-            // 'fecha_actividad' ya no se pasa, se guardará como NULL por defecto
             'user_id' => $user_id,
-            'sesion_id' => $actividad_prog->sesion_id, // Pasar el ID de la sesión
+            'sesion_id' => $actividad_prog->sesion_id,
+            'orden' => $actividad_prog->orden
         ];
 
-        $actividad_calificable_id = cpp_guardar_actividad_evaluable($datos_actividad_calificable);
+        if ($actividad_cuaderno) {
+            $actividad_calificable_id = $actividad_cuaderno->id;
+            cpp_actualizar_actividad_evaluable($actividad_calificable_id, $datos_cuaderno);
+        } else {
+            $actividad_calificable_id = cpp_guardar_actividad_evaluable($datos_cuaderno);
+        }
 
         if (!$actividad_calificable_id) {
-            wp_send_json_error(['message' => 'Error al crear la actividad en el cuaderno.']);
+            wp_send_json_error(['message' => 'Error al crear o actualizar la actividad en el cuaderno.']);
             return;
         }
 
-        // Actualizar la actividad del programador con el ID de la actividad calificable
-        $update_data = [
+        // Sincronizar record del programador
+        $wpdb->update($tabla_prog_act, [
             'es_evaluable' => 1,
-            'actividad_calificable_id' => $actividad_calificable_id,
-        ];
-        $wpdb->update($tabla_programador_actividades, $update_data, ['id' => $actividad_id]);
+            'actividad_calificable_id' => $actividad_calificable_id
+        ], ['id' => $actividad_id_prog]);
 
     } else {
-        // --- Marcar como NO EVALUABLE ---
-        $actividad_calificable_id = $actividad_prog->actividad_calificable_id;
-        if ($actividad_calificable_id) {
-            cpp_eliminar_actividad_y_calificaciones($actividad_calificable_id, $user_id);
+        // --- CONVERTIR A TAREA (NO EVALUABLE) ---
+        if ($actividad_cuaderno) {
+            cpp_eliminar_actividad_y_calificaciones($actividad_cuaderno->id, $user_id);
         }
 
-        // Actualizar la actividad del programador
-        $update_data = [
+        // Marcar en programador como no evaluable
+        $wpdb->update($tabla_prog_act, [
             'es_evaluable' => 0,
-            'actividad_calificable_id' => null,
-        ];
-        $wpdb->update($tabla_programador_actividades, $update_data, ['id' => $actividad_id]);
+            'actividad_calificable_id' => null
+        ], ['id' => $actividad_id_prog]);
     }
 
-    $actividad_actualizada = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_programador_actividades WHERE id = %d", $actividad_id), ARRAY_A);
+    $actividad_actualizada = $wpdb->get_row($wpdb->prepare("SELECT * FROM $tabla_prog_act WHERE id = %d", $actividad_id_prog), ARRAY_A);
 
     if ($actividad_actualizada) {
-        // FIX: Devolver los IDs para que el frontend pueda renderizar el selector correctamente.
+        // Devolver los IDs para que el frontend pueda renderizar el selector correctamente.
         $actividad_actualizada['categoria_id'] = $categoria_id;
         $actividad_actualizada['criterio_id'] = $criterio_id;
         $actividad_actualizada['tipo'] = $actividad_actualizada['es_evaluable'] ? 'evaluable' : 'no_evaluable';

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -81,7 +81,7 @@ function cpp_programador_get_all_data($user_id) {
         $placeholders = implode(',', array_fill(0, count($sesiones_ids), '%d'));
 
         // Cargar actividades NO evaluables
-        $actividades_no_evaluables = $wpdb->get_results($wpdb->prepare("SELECT *, 'no_evaluable' as tipo FROM $tabla_actividades WHERE sesion_id IN ($placeholders)", $sesiones_ids));
+        $actividades_no_evaluables = $wpdb->get_results($wpdb->prepare("SELECT *, 'no_evaluable' as tipo FROM $tabla_actividades WHERE sesion_id IN ($placeholders) AND (es_evaluable = 0 OR es_evaluable IS NULL)", $sesiones_ids));
 
         // Cargar actividades EVALUABLES
         $tabla_evaluables = $wpdb->prefix . 'cpp_actividades_evaluables';

--- a/includes/programador/db-programador.php
+++ b/includes/programador/db-programador.php
@@ -85,7 +85,7 @@ function cpp_programador_get_all_data($user_id) {
 
         // Cargar actividades EVALUABLES
         $tabla_evaluables = $wpdb->prefix . 'cpp_actividades_evaluables';
-        $actividades_evaluables = $wpdb->get_results($wpdb->prepare("SELECT id, sesion_id, nombre_actividad as titulo, orden, 'evaluable' as tipo FROM $tabla_evaluables WHERE sesion_id IN ($placeholders)", $sesiones_ids));
+        $actividades_evaluables = $wpdb->get_results($wpdb->prepare("SELECT id, sesion_id, nombre_actividad as titulo, criterio_id, orden, 'evaluable' as tipo FROM $tabla_evaluables WHERE sesion_id IN ($placeholders)", $sesiones_ids));
 
         // Unir y ordenar
         $todas_las_actividades = array_merge($actividades_no_evaluables, $actividades_evaluables);

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -818,12 +818,15 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         <div class="cpp-form-group"><label for="fecha_actividad_cuaderno_input">Fecha:</label><input type="date" id="fecha_actividad_cuaderno_input" name="fecha_actividad"><div id="cpp-fecha-actividad-display" style="display: none; padding: 8px 0; font-size: 14px; color: #555;"></div></div>
                         <div class="cpp-form-group"><label for="descripcion_actividad_cuaderno_textarea">Descripción (opcional):</label><textarea id="descripcion_actividad_cuaderno_textarea" name="descripcion_actividad" rows="3"></textarea></div>
                         
-                        <div class="cpp-modal-actions" style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 20px;">
-                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-actividad-btn-modal" style="display: none; margin-right: 10px;">
-                                <span class="dashicons dashicons-trash"></span> Eliminar Actividad
+                        <div id="cpp-modal-actividad-conversion-area" style="border-top: 1px solid #e0e0e0; padding-top: 15px; margin-top: 20px; display: none;">
+                            <button type="button" class="cpp-btn cpp-btn-secondary" id="cpp-convertir-tarea-btn-modal" style="width: 100%; justify-content: center;" title="Convertir esta actividad en una tarea no evaluable">
+                                <span class="dashicons dashicons-clipboard"></span> Convertir en Tarea (No Evaluable)
                             </button>
-                            <button type="button" class="cpp-btn cpp-btn-secondary" id="cpp-convertir-tarea-btn-modal" style="display: none; margin-right: auto;" title="Convertir esta actividad en una tarea no evaluable">
-                                <span class="dashicons dashicons-star-empty"></span> Convertir en Tarea
+                        </div>
+
+                        <div class="cpp-modal-actions" style="padding-top: 15px; margin-top: 0;">
+                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-actividad-btn-modal" style="display: none; margin-right: auto;">
+                                <span class="dashicons dashicons-trash"></span> Eliminar Actividad
                             </button>
                             <button type="submit" class="cpp-btn cpp-btn-primary" id="cpp-submit-actividad-btn-cuaderno-form">
                                 <span class="dashicons dashicons-saved"></span> Guardar Actividad

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -819,8 +819,11 @@ function cpp_shortcode_cuaderno_notas_classroom() {
                         <div class="cpp-form-group"><label for="descripcion_actividad_cuaderno_textarea">Descripción (opcional):</label><textarea id="descripcion_actividad_cuaderno_textarea" name="descripcion_actividad" rows="3"></textarea></div>
                         
                         <div class="cpp-modal-actions" style="border-top: 1px solid #e0e0e0; padding-top: 20px; margin-top: 20px;">
-                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-actividad-btn-modal" style="display: none; margin-right: auto;">
+                            <button type="button" class="cpp-btn cpp-btn-danger" id="cpp-eliminar-actividad-btn-modal" style="display: none; margin-right: 10px;">
                                 <span class="dashicons dashicons-trash"></span> Eliminar Actividad
+                            </button>
+                            <button type="button" class="cpp-btn cpp-btn-secondary" id="cpp-convertir-tarea-btn-modal" style="display: none; margin-right: auto;" title="Convertir esta actividad en una tarea no evaluable">
+                                <span class="dashicons dashicons-star-empty"></span> Convertir en Tarea
                             </button>
                             <button type="submit" class="cpp-btn cpp-btn-primary" id="cpp-submit-actividad-btn-cuaderno-form">
                                 <span class="dashicons dashicons-saved"></span> Guardar Actividad


### PR DESCRIPTION
This change allows users to convert activities from evaluable to non-evaluable (tasks) and vice versa. 

Key features:
1. **Programmer View:** Added a star icon to each activity in the session detail panel to toggle its evaluable state.
2. **Activities View:** 
   - Non-evaluable tasks are now visible alongside evaluable ones in the default view.
   - Added a new "Tareas no evaluables" filter option.
   - Each row features a toggle button to change the activity type.
3. **Data Integrity:** 
   - Converting to non-evaluable prompts for confirmation, warning that grades will be deleted.
   - Converting to evaluable prompts for a global criterion (if the evaluation is weighted).
4. **Backend Synchronization:** 
   - Correctly links and unlinks records between `cpp_actividades_evaluables` and `cpp_programador_actividades`.
   - Ensures activity names remain synced when edited inline.
   - Verified PHP syntax across all modified files.

---
*PR created automatically by Jules for task [10737918021416331853](https://jules.google.com/task/10737918021416331853) started by @vegasmadrid*